### PR TITLE
Login screen fix

### DIFF
--- a/app/src/main/java/com/example/loryblu/createpassword/CreatePasswordScreen.kt
+++ b/app/src/main/java/com/example/loryblu/createpassword/CreatePasswordScreen.kt
@@ -71,7 +71,8 @@ fun CreatePasswordScreen(
             onButtonClick = { passwordHidden = !passwordHidden },
             labelRes = stringResource(id = R.string.password),
             value = uiState.password,
-            hidden =  passwordHidden
+            error = uiState.passwordState,
+            hidden = passwordHidden,
         )
 
         Column(
@@ -147,6 +148,7 @@ fun CreatePasswordScreen(
             onButtonClick = { passwordHidden = !passwordHidden },
             labelRes = stringResource(id = R.string.confirm_password),
             value = uiState.confirmationPassword,
+            error = uiState.passwordState,
             hidden = passwordHidden
         )
 

--- a/app/src/main/java/com/example/loryblu/createpassword/CreatePasswordScreen.kt
+++ b/app/src/main/java/com/example/loryblu/createpassword/CreatePasswordScreen.kt
@@ -15,6 +15,9 @@ package com.example.loryblu.createpassword
  import androidx.compose.material3.Text
  import androidx.compose.runtime.Composable
  import androidx.compose.runtime.getValue
+ import androidx.compose.runtime.mutableStateOf
+ import androidx.compose.runtime.saveable.rememberSaveable
+ import androidx.compose.runtime.setValue
  import androidx.compose.ui.Alignment
  import androidx.compose.ui.Modifier
  import androidx.compose.ui.graphics.Color
@@ -43,6 +46,8 @@ fun CreatePasswordScreen(
             .fillMaxSize()
     ) {
         val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+        var passwordHidden by rememberSaveable { mutableStateOf(true) }
+
 
         LBTitle(textRes = R.string.create_a_new_password)
 
@@ -63,10 +68,10 @@ fun CreatePasswordScreen(
                     passwordCheck(newPassword = newPassword)
                 }
             },
-            onButtonClick = { viewModel.togglePassword() },
+            onButtonClick = { passwordHidden = !passwordHidden },
             labelRes = R.string.password,
             value = uiState.password,
-            show = uiState.showPassword
+            hidden =  passwordHidden
         )
 
         Column(
@@ -139,10 +144,10 @@ fun CreatePasswordScreen(
                     verifyConfirmationPassword(newConfirmationPassword)
                 }
             },
-            onButtonClick = { viewModel.toggleConfirmationPassword() },
+            onButtonClick = { passwordHidden = !passwordHidden },
             labelRes = R.string.confirm_password,
             value = uiState.confirmationPassword,
-            show = uiState.showConfirmationPassword
+            hidden = passwordHidden
         )
 
         if (uiState.equalsPassword == false) {

--- a/app/src/main/java/com/example/loryblu/createpassword/CreatePasswordScreen.kt
+++ b/app/src/main/java/com/example/loryblu/createpassword/CreatePasswordScreen.kt
@@ -69,7 +69,7 @@ fun CreatePasswordScreen(
                 }
             },
             onButtonClick = { passwordHidden = !passwordHidden },
-            labelRes = R.string.password,
+            labelRes = stringResource(id = R.string.password),
             value = uiState.password,
             hidden =  passwordHidden
         )
@@ -145,7 +145,7 @@ fun CreatePasswordScreen(
                 }
             },
             onButtonClick = { passwordHidden = !passwordHidden },
-            labelRes = R.string.confirm_password,
+            labelRes = stringResource(id = R.string.confirm_password),
             value = uiState.confirmationPassword,
             hidden = passwordHidden
         )

--- a/app/src/main/java/com/example/loryblu/createpassword/CreatePasswordViewModel.kt
+++ b/app/src/main/java/com/example/loryblu/createpassword/CreatePasswordViewModel.kt
@@ -3,6 +3,7 @@ package com.example.loryblu.createpassword
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.loryblu.R
+import com.example.loryblu.login.PasswordInputValid
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -12,6 +13,7 @@ data class UiStateCreatePassword(
     val showConfirmationPassword: Boolean = false,
     val password: String = "",
     val confirmationPassword: String = "",
+    val passwordState: PasswordInputValid = PasswordInputValid.Empty,
     val passwordHas: Map<Int, Boolean> = mapOf(
         R.string.MoreThanEight to false,
         R.string.Uppercase to false,
@@ -21,6 +23,7 @@ data class UiStateCreatePassword(
     ),
     val equalsPassword: Boolean? = null
 )
+
 class CreatePasswordViewModel constructor(): ViewModel() {
     private val _uiState = MutableStateFlow(UiStateCreatePassword())
     val uiState = _uiState

--- a/app/src/main/java/com/example/loryblu/forgotpassword/ForgotPasswordScreen.kt
+++ b/app/src/main/java/com/example/loryblu/forgotpassword/ForgotPasswordScreen.kt
@@ -72,17 +72,18 @@ fun ForgotPasswordScreen(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        // se o id do problema for null isso siginifica que esta carregando a procura de erros no e-mail
-        viewModel.idEmailProblem()?.run {
-            Text(
-                text = stringResource(id = this@run),
-                style = MaterialTheme.typography.labelMedium,
-                color = Error
-            )
-        } ?: run {
-            // TODO
-            // fazer uma animação de carregamento
-        }
+        // TODO Verificar como ficará o código apos mudanças no viewModel
+//        // se o id do problema for null isso siginifica que esta carregando a procura de erros no e-mail
+//        viewModel.idEmailProblem()?.run {
+//            Text(
+//                text = stringResource(id = this@run),
+//                style = MaterialTheme.typography.labelMedium,
+//                color = Error
+//            )
+//        } ?: run {
+//            // TODO
+//            // fazer uma animação de carregamento
+//        }
 
         Spacer(modifier = Modifier.height(P_MEDIUM))
 

--- a/app/src/main/java/com/example/loryblu/forgotpassword/ForgotPasswordScreen.kt
+++ b/app/src/main/java/com/example/loryblu/forgotpassword/ForgotPasswordScreen.kt
@@ -24,7 +24,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.loryblu.R
 import com.example.loryblu.ui.components.LBButton
 import com.example.loryblu.ui.components.LBTitle
-import com.example.loryblu.ui.theme.Error
 import com.example.loryblu.util.P_MEDIUM
 import com.example.loryblu.util.P_SMALL
 

--- a/app/src/main/java/com/example/loryblu/forgotpassword/ForgotPasswordViewModel.kt
+++ b/app/src/main/java/com/example/loryblu/forgotpassword/ForgotPasswordViewModel.kt
@@ -43,18 +43,4 @@ class ForgotPasswordViewModel constructor() : ViewModel() {
         }
 
     }
-
-    /**
-     * Verified if the e-mail has some problem, while search for that on e-mail.
-     */
-    fun idEmailProblem(): Int? {
-        val state = when (_uiState.value.emailState) {
-            EmailState.NOT_FOUND -> R.string.email_not_found
-            EmailState.SEND -> R.string.email_send
-            EmailState.EMPTY -> R.string.empty_email
-            EmailState.NONE -> R.string.empty_string
-            EmailState.LOADING -> null
-        }
-        return state
-    }
 }

--- a/app/src/main/java/com/example/loryblu/forgotpassword/ForgotPasswordViewModel.kt
+++ b/app/src/main/java/com/example/loryblu/forgotpassword/ForgotPasswordViewModel.kt
@@ -1,7 +1,6 @@
 package com.example.loryblu.forgotpassword
 
 import androidx.lifecycle.ViewModel
-import com.example.loryblu.R
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 

--- a/app/src/main/java/com/example/loryblu/login/EmailExtensions.kt
+++ b/app/src/main/java/com/example/loryblu/login/EmailExtensions.kt
@@ -1,0 +1,5 @@
+package com.example.loryblu.login
+
+import android.util.Patterns
+
+fun String.isEmailValid() : Boolean = Patterns.EMAIL_ADDRESS.matcher(this).matches()

--- a/app/src/main/java/com/example/loryblu/login/EmailProblem.kt
+++ b/app/src/main/java/com/example/loryblu/login/EmailProblem.kt
@@ -1,7 +1,7 @@
 package com.example.loryblu.login
 
 sealed class EmailInputValid {
-    object Success: EmailInputValid()
+    object Valid: EmailInputValid()
     data class Error(val messageId: Int): EmailInputValid()
     object Empty: EmailInputValid()
 }

--- a/app/src/main/java/com/example/loryblu/login/EmailProblem.kt
+++ b/app/src/main/java/com/example/loryblu/login/EmailProblem.kt
@@ -1,12 +1,7 @@
 package com.example.loryblu.login
 
-enum class EmailProblem {
-    // invalido
-    INVALID,
-    // vazio
-    EMPTY,
-    // inexistente
-    ABSENT,
-    // nemhum
-    NONE,
+sealed class EmailInputValid {
+    object Success: EmailInputValid()
+    data class Error(val messageId: Int): EmailInputValid()
+    object Empty: EmailInputValid()
 }

--- a/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
@@ -8,30 +8,23 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -42,12 +35,10 @@ import com.example.loryblu.ui.components.LBEmailTextField
 import com.example.loryblu.ui.components.LBPasswordTextField
 import com.example.loryblu.ui.components.LBTitle
 import com.example.loryblu.ui.theme.DarkBlue
-import com.example.loryblu.ui.theme.Error
 import com.example.loryblu.util.P_LARGE
 import com.example.loryblu.util.P_MEDIUM
 import com.example.loryblu.util.P_SMALL
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LoginScreen(
     viewModel: LoginViewModel,
@@ -90,10 +81,11 @@ fun LoginScreen(
                 updatePassword(newPassword)
             }},
             onButtonClick = { passwordHidden = !passwordHidden },
-            labelRes = R.string.password,
+            labelRes = stringResource(id = R.string.password),
             value = uiState.password,
             hidden = passwordHidden
         )
+
         Spacer(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -22,17 +24,21 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.loryblu.R
 import com.example.loryblu.ui.components.LBButton
+import com.example.loryblu.ui.components.LBEmailTextField
 import com.example.loryblu.ui.components.LBPasswordTextField
 import com.example.loryblu.ui.components.LBTitle
 import com.example.loryblu.ui.theme.DarkBlue
@@ -52,6 +58,8 @@ fun LoginScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var passwordHidden by rememberSaveable { mutableStateOf(true) }
 
+
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
@@ -61,33 +69,25 @@ fun LoginScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        OutlinedTextField(
-            value = uiState.email,
+        LBEmailTextField(
             onValueChange = { it: String ->
                 viewModel.updateEmail(it)
                 viewModel.emailState(email = it)
             },
-            leadingIcon = {
-                Icon(
-                    painterResource(id = R.drawable.ic_email),
-                    contentDescription = stringResource(R.string.mail_icon)
-                )
-            },
-            label = { Text(text = stringResource(R.string.email)) },
-            textStyle = MaterialTheme.typography.bodyLarge,
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth(),
+            labelRes = stringResource(R.string.email),
+            value = uiState.email,
+            error = uiState.emailProblem,
         )
+
         Spacer(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(P_MEDIUM)
         )
-        // tem o problema que caso eu coloque os modifier que estava no figma ele mostra o texto enquando estou digitando
+
         LBPasswordTextField(
             onValueChange = { newPassword: String  -> viewModel.run {
                 updatePassword(newPassword)
-
             }},
             onButtonClick = { passwordHidden = !passwordHidden },
             labelRes = R.string.password,
@@ -114,13 +114,13 @@ fun LoginScreen(
                 modifier = Modifier.weight(2f),
                 maxLines = 1
             )
-            Text(
-                text = stringResource(viewModel.idEmailProblem()),
-                modifier = Modifier.weight(2f),
-                maxLines = 1,
-                color = Error,
-                style = MaterialTheme.typography.labelLarge
-            )
+//            Text(
+//                text = stringResource(uiState.emailProblem),
+//                modifier = Modifier.weight(2f),
+//                maxLines = 1,
+//                color = Error,
+//                style = MaterialTheme.typography.labelLarge
+//            )
         }
         LBButton(
             textRes = R.string.login,

--- a/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
@@ -18,6 +18,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -47,6 +50,8 @@ fun LoginScreen(
     navigateToGuardianRegister: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var passwordHidden by rememberSaveable { mutableStateOf(true) }
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
@@ -84,10 +89,10 @@ fun LoginScreen(
                 updatePassword(newPassword)
 
             }},
-            onButtonClick = { /*TODO*/ },
+            onButtonClick = { passwordHidden = !passwordHidden },
             labelRes = R.string.password,
             value = uiState.password,
-            show = uiState.showPassword
+            hidden = passwordHidden
         )
         Spacer(
             modifier = Modifier
@@ -110,7 +115,7 @@ fun LoginScreen(
                 maxLines = 1
             )
             Text(
-                text = stringResource(viewModel.IdEmailProblem()),
+                text = stringResource(viewModel.idEmailProblem()),
                 modifier = Modifier.weight(2f),
                 maxLines = 1,
                 color = Error,

--- a/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
@@ -46,6 +46,8 @@ fun LoginScreen(
     authenticated: Boolean,
     onLoginButtonClicked: () -> Unit,
     navigateToGuardianRegister: () -> Unit,
+    navigateToForgotPassword: () -> Unit,
+    navigateToRegisterNow: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var passwordHidden by rememberSaveable { mutableStateOf(true) }
@@ -145,7 +147,7 @@ fun LoginScreen(
                 .fillMaxWidth()
         ) {
             TextButton(
-                onClick = { /*TODO*/ },
+                onClick = { navigateToForgotPassword() },
                 colors = ButtonDefaults.textButtonColors(
                     contentColor = Color.Black
                 )
@@ -186,7 +188,7 @@ fun LoginScreen(
                 style = MaterialTheme.typography.bodyLarge,
             )
             TextButton(
-                onClick = { /*TODO*/ }
+                onClick = { navigateToRegisterNow() }
             ) {
                 Text(
                     text = stringResource(R.string.register_now),
@@ -217,7 +219,13 @@ fun PreviewComposable() {
         },
         navigateToGuardianRegister = {
 
-        }
+        },
+        navigateToForgotPassword = {
+
+        },
+        navigateToRegisterNow = {
+
+        },
     )
 }
 

--- a/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
@@ -60,13 +60,13 @@ fun LoginScreen(
         Spacer(modifier = Modifier.height(16.dp))
 
         LBEmailTextField(
-            onValueChange = { it: String ->
-                viewModel.updateEmail(it)
-                viewModel.emailState(email = it)
+            onValueChange = { email: String ->
+                viewModel.emailState(email = email)
+                viewModel.updateEmail(email)
             },
-            labelRes = stringResource(R.string.email),
+            labelRes = stringResource(id = R.string.email),
             value = uiState.email,
-            error = uiState.emailProblem,
+            error = uiState.emailState,
         )
 
         Spacer(
@@ -76,12 +76,14 @@ fun LoginScreen(
         )
 
         LBPasswordTextField(
-            onValueChange = { newPassword: String  -> viewModel.run {
-                updatePassword(newPassword)
+            onValueChange = { password: String  -> viewModel.run {
+                viewModel.passwordState(password)
+                updatePassword(password)
             }},
             onButtonClick = { passwordHidden = !passwordHidden },
             labelRes = stringResource(id = R.string.password),
             value = uiState.password,
+            error = uiState.passwordState,
             hidden = passwordHidden
         )
 
@@ -105,13 +107,6 @@ fun LoginScreen(
                 modifier = Modifier.weight(2f),
                 maxLines = 1
             )
-//            Text(
-//                text = stringResource(uiState.emailProblem),
-//                modifier = Modifier.weight(2f),
-//                maxLines = 1,
-//                color = Error,
-//                style = MaterialTheme.typography.labelLarge
-//            )
         }
         LBButton(
             textRes = R.string.login,

--- a/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
@@ -94,17 +94,15 @@ fun LoginScreen(
         )
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Start,
+            horizontalArrangement = Arrangement.End,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(P_MEDIUM)
         ) {
             Checkbox(checked = uiState.isLoginSaved, onCheckedChange = { viewModel.toggleIsLoginSaved() })
-            Spacer(modifier = Modifier.weight(2f))
             Text(
                 text = stringResource(R.string.remember),
                 color = Color.Black,
-                modifier = Modifier.weight(2f),
                 maxLines = 1
             )
         }
@@ -159,7 +157,6 @@ fun LoginScreen(
                 contentDescription = stringResource(R.string.google_logo),
                 modifier = Modifier.weight(1f)
             )
-//            Spacer(modifier = Modifier.weight(1f))
             Image(
                 painter = painterResource(id = R.drawable.ic_facebook),
                 contentDescription = stringResource(R.string.facebook_logo),

--- a/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
@@ -8,10 +8,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -136,14 +138,24 @@ fun LoginScreen(
                 thickness = 2.dp
             )
         }
-        Row(horizontalArrangement = Arrangement.Start, modifier = Modifier.padding(top = 4.dp)) {
-            Spacer(modifier = Modifier.weight(6f))
-            Text(
-                text = stringResource(R.string.forgot_password),
-                fontSize = MaterialTheme.typography.bodyLarge.fontSize,
-                textDecoration = TextDecoration.Underline,
-                modifier = Modifier.weight(4f)
-            )
+        Row(
+            horizontalArrangement = Arrangement.End,
+            modifier = Modifier
+                .padding(top = 4.dp)
+                .fillMaxWidth()
+        ) {
+            TextButton(
+                onClick = { /*TODO*/ },
+                colors = ButtonDefaults.textButtonColors(
+                    contentColor = Color.Black
+                )
+            ) {
+                Text(
+                    text = stringResource(R.string.forgot_password),
+                    fontSize = MaterialTheme.typography.bodyLarge.fontSize,
+                    textDecoration = TextDecoration.Underline,
+                )
+            }
         }
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -165,7 +177,7 @@ fun LoginScreen(
         }
 
         Row(
-            horizontalArrangement = Arrangement.SpaceEvenly,
+            horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth()
         ) {
@@ -173,12 +185,16 @@ fun LoginScreen(
                 text = stringResource(R.string.don_t_have_an_account),
                 style = MaterialTheme.typography.bodyLarge,
             )
-            Text(
-                text = stringResource(R.string.register_now),
-                style = MaterialTheme.typography.bodyLarge,
-                color = DarkBlue,
-                textDecoration = TextDecoration.Underline
-            )
+            TextButton(
+                onClick = { /*TODO*/ }
+            ) {
+                Text(
+                    text = stringResource(R.string.register_now),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = DarkBlue,
+                    textDecoration = TextDecoration.Underline
+                )
+            }
         }
 
     }

--- a/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/loryblu/login/LoginScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Divider
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/com/example/loryblu/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/loryblu/login/LoginViewModel.kt
@@ -67,7 +67,7 @@ class LoginViewModel constructor(
             it.copy(isLoginSaved = it.isLoginSaved.not())
         }
     }
-    fun IdEmailProblem(): Int {
+    fun idEmailProblem(): Int {
         val problem =  when (_uiState.value.emailProblem) {
             EmailProblem.INVALID -> R.string.invalid_e_mail
             EmailProblem.EMPTY -> R.string.required_field

--- a/app/src/main/java/com/example/loryblu/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/loryblu/login/LoginViewModel.kt
@@ -11,9 +11,9 @@ import kotlinx.coroutines.launch
 
 data class LoginUiState(
     val email: String = "",
-    val emailProblem: EmailInputValid = EmailInputValid.Empty,
+    val emailState: EmailInputValid = EmailInputValid.Empty,
     val password: String = "",
-    val passwordProblem: PasswordProblem = PasswordProblem.EMPTY,
+    val passwordState: PasswordInputValid = PasswordInputValid.Empty,
     // serve para salvar o estado para a proxima visita
     val isLoginSaved: Boolean = true,
     val enterTrigger: Boolean = false,
@@ -33,17 +33,17 @@ class LoginViewModel constructor(
         when {
             email.isEmpty() -> {
                 _uiState.update {
-                    it.copy(emailProblem = EmailInputValid.Error(R.string.empty_email))
+                    it.copy(emailState = EmailInputValid.Error(R.string.empty_email))
                 }
             }
             email.isEmailValid().not() -> {
                 _uiState.update {
-                    it.copy(emailProblem = EmailInputValid.Error(R.string.invalid_e_mail))
+                    it.copy(emailState = EmailInputValid.Error(R.string.invalid_e_mail))
                 }
             }
             else -> {
                 _uiState.update {
-                    it.copy(emailProblem = EmailInputValid.Success)
+                    it.copy(emailState = EmailInputValid.Success)
                 }
             }
         }
@@ -66,14 +66,18 @@ class LoginViewModel constructor(
         }
     }
 
-    fun verifyPassword(newPassword: String) {
+    fun passwordState(newPassword: String) {
         when {
-            newPassword.trim() == "" -> {
+            newPassword.isEmpty() -> {
                 _uiState.update {
-                    it.copy(passwordProblem = PasswordProblem.EMPTY)
+                    it.copy(passwordState = PasswordInputValid.Error(R.string.password_is_empty))
                 }
             }
-            // procura no banco de dados pelas informações de login da pessoa
+            else -> {
+                _uiState.update {
+                    it.copy(passwordState = PasswordInputValid.Valid)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/example/loryblu/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/loryblu/login/LoginViewModel.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.launch
 
 data class LoginUiState(
     val email: String = "",
-    val emailProblem: EmailProblem = EmailProblem.EMPTY,
+    val emailProblem: EmailInputValid = EmailInputValid.Empty,
     val password: String = "",
     val passwordProblem: PasswordProblem = PasswordProblem.EMPTY,
     // serve para salvar o estado para a proxima visita
@@ -30,24 +30,22 @@ class LoginViewModel constructor(
         private set
 
     fun emailState(email: String) {
-        val regex = Regex("(\\w)+[\\.|-]?(\\w)+@(\\w|-)+\\.((\\w){2,})(\\.([a-zA-z0-9])+)*$")
         when {
-            "" == email.trim() -> {
+            email.isEmpty() -> {
                 _uiState.update {
-                    it.copy(emailProblem = EmailProblem.EMPTY)
+                    it.copy(emailProblem = EmailInputValid.Error(R.string.empty_email))
                 }
             }
-            regex.containsMatchIn(email).not() -> {
+            email.isEmailValid().not() -> {
                 _uiState.update {
-                    it.copy(emailProblem = EmailProblem.INVALID)
+                    it.copy(emailProblem = EmailInputValid.Error(R.string.invalid_e_mail))
                 }
             }
             else -> {
                 _uiState.update {
-                    it.copy(emailProblem = EmailProblem.NONE)
+                    it.copy(emailProblem = EmailInputValid.Success)
                 }
             }
-            // TODO aqui eu preciso achar a api para consultar e ver se o email é existente no sistema
         }
     }
     fun updateEmail(newEmail: String) {
@@ -66,15 +64,6 @@ class LoginViewModel constructor(
         _uiState.update {
             it.copy(isLoginSaved = it.isLoginSaved.not())
         }
-    }
-    fun idEmailProblem(): Int {
-        val problem =  when (_uiState.value.emailProblem) {
-            EmailProblem.INVALID -> R.string.invalid_e_mail
-            EmailProblem.EMPTY -> R.string.required_field
-            EmailProblem.ABSENT -> R.string.empty_email
-            EmailProblem.NONE -> R.string.empty_string
-        }
-        return problem
     }
 
     fun toggleVisibility() {

--- a/app/src/main/java/com/example/loryblu/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/loryblu/login/LoginViewModel.kt
@@ -66,14 +66,6 @@ class LoginViewModel constructor(
         }
     }
 
-    fun toggleVisibility() {
-        viewModelScope.launch {
-            _uiState.update {
-                it.copy(showPassword = _uiState.value.showPassword.not())
-            }
-        }
-    }
-
     fun verifyPassword(newPassword: String) {
         when {
             newPassword.trim() == "" -> {

--- a/app/src/main/java/com/example/loryblu/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/loryblu/login/LoginViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.loryblu.login
 
+import android.util.Log
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -43,7 +44,7 @@ class LoginViewModel constructor(
             }
             else -> {
                 _uiState.update {
-                    it.copy(emailState = EmailInputValid.Success)
+                    it.copy(emailState = EmailInputValid.Valid)
                 }
             }
         }
@@ -82,10 +83,16 @@ class LoginViewModel constructor(
     }
 
     fun loginWithEmailAndPassword() {
-        // TODO Lógica para verificar se está logado com a auth db
         viewModelScope.launch {
-            delay(300)
-            authenticated.value = true
+            // Essa verificação mudará para uma verificação com a db
+            if(uiState.value.passwordState is PasswordInputValid.Valid && uiState.value.emailState is EmailInputValid.Valid){
+                delay(300)
+                authenticated.value = true
+            }
+           else {
+               authenticated.value = false
+               Log.d("LoginViewModel", "Password or email is not valid")
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/loryblu/login/PasswordProblem.kt
+++ b/app/src/main/java/com/example/loryblu/login/PasswordProblem.kt
@@ -1,7 +1,7 @@
 package com.example.loryblu.login
 
-enum class PasswordProblem {
-    NONE,
-    WRONG,
-    EMPTY,
+sealed class PasswordInputValid {
+    object Valid: PasswordInputValid()
+    data class Error(val messageId: Int): PasswordInputValid()
+    object Empty: PasswordInputValid()
 }

--- a/app/src/main/java/com/example/loryblu/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/loryblu/navigation/NavGraph.kt
@@ -7,6 +7,10 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.example.loryblu.createpassword.CreatePasswordScreen
+import com.example.loryblu.createpassword.CreatePasswordViewModel
+import com.example.loryblu.forgotpassword.ForgotPasswordScreen
+import com.example.loryblu.forgotpassword.ForgotPasswordViewModel
 import com.example.loryblu.login.LoginScreen
 import com.example.loryblu.login.LoginViewModel
 import com.example.loryblu.register.child.ChildRegisterScreen
@@ -21,13 +25,17 @@ fun SetupNavGraph(startDestination: String, navController: NavHostController) {
     ) {
         loginRoute(
             navigateToGuardianRegister = {
-                navController.popBackStack()
+                navController.navigate(Screen.RegisterGuardian.route)
+            },
+            navigateToForgotPassword = {
+                navController.navigate(Screen.ForgetPassword.route)
+            },
+            navigateToRegisterNow = {
                 navController.navigate(Screen.RegisterGuardian.route)
             }
         )
         registerGuardianRoute(
             navigateToChildRegister = {
-                navController.popBackStack()
                 navController.navigate(Screen.RegisterChild.route)
             }
         )
@@ -39,6 +47,8 @@ fun SetupNavGraph(startDestination: String, navController: NavHostController) {
 
 fun NavGraphBuilder.loginRoute(
     navigateToGuardianRegister: () -> Unit,
+    navigateToForgotPassword: () -> Unit,
+    navigateToRegisterNow: () -> Unit,
 ) {
     composable(route = Screen.Login.route) {
         val viewModel: LoginViewModel = viewModel()
@@ -52,6 +62,8 @@ fun NavGraphBuilder.loginRoute(
                 viewModel.loginWithEmailAndPassword()
             },
             navigateToGuardianRegister = navigateToGuardianRegister,
+            navigateToRegisterNow = navigateToRegisterNow,
+            navigateToForgotPassword = navigateToForgotPassword,
         )
     }
 }
@@ -79,12 +91,21 @@ fun NavGraphBuilder.registerChildRoute() {
 
 fun NavGraphBuilder.createPasswordRoute() {
     composable(route = Screen.CreatePassword.route) {
-
+        val viewModel: CreatePasswordViewModel = viewModel()
+        CreatePasswordScreen(
+            viewModel = viewModel,
+        )
     }
 }
 
 fun NavGraphBuilder.forgotPasswordRoute() {
     composable(route = Screen.ForgetPassword.route) {
+        val viewModel: ForgotPasswordViewModel = viewModel()
+        ForgotPasswordScreen(
+            viewModel = viewModel,
+            navigateToNextScreen = {
 
+            }
+        )
     }
 }

--- a/app/src/main/java/com/example/loryblu/register/guardian/GuardianRegisterScreen.kt
+++ b/app/src/main/java/com/example/loryblu/register/guardian/GuardianRegisterScreen.kt
@@ -18,6 +18,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -40,6 +43,8 @@ fun GuardianRegisterScreen(
     navigateToChildRegister: () -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    var passwordHidden by rememberSaveable { mutableStateOf(true) }
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.SpaceEvenly,
@@ -96,11 +101,11 @@ fun GuardianRegisterScreen(
                    }
                },
                onButtonClick = {
-                               viewModel.togglePassword()
+                   passwordHidden = !passwordHidden
                },
                labelRes = R.string.password,
                value = uiState.password,
-               show = uiState.showPassword
+               hidden = passwordHidden
            )
 //            Spacer(modifier = Modifier.height(16.dp))
             Column(
@@ -174,10 +179,10 @@ fun GuardianRegisterScreen(
                        verifyConfirmationPassword(newPassConfir)
                    }
                },
-               onButtonClick = { viewModel.toggleConfirmationPassword() },
+               onButtonClick = { passwordHidden = !passwordHidden },
                labelRes = R.string.confirm_password,
                value = uiState.confirmationPassword,
-               show = uiState.showConfirmationPassword
+               hidden = passwordHidden
            )
 
             if (uiState.equalsPassword == false) {

--- a/app/src/main/java/com/example/loryblu/register/guardian/GuardianRegisterScreen.kt
+++ b/app/src/main/java/com/example/loryblu/register/guardian/GuardianRegisterScreen.kt
@@ -104,6 +104,7 @@ fun GuardianRegisterScreen(
                },
                labelRes = stringResource(id = R.string.password),
                value = uiState.password,
+               error = uiState.passwordState,
                hidden = passwordHidden
            )
 //            Spacer(modifier = Modifier.height(16.dp))
@@ -181,7 +182,8 @@ fun GuardianRegisterScreen(
                onButtonClick = { passwordHidden = !passwordHidden },
                labelRes = stringResource(id = R.string.confirm_password),
                value = uiState.confirmationPassword,
-               hidden = passwordHidden
+               error = uiState.passwordState,
+               hidden = passwordHidden,
            )
 
             if (uiState.equalsPassword == false) {

--- a/app/src/main/java/com/example/loryblu/register/guardian/GuardianRegisterScreen.kt
+++ b/app/src/main/java/com/example/loryblu/register/guardian/GuardianRegisterScreen.kt
@@ -34,7 +34,6 @@ import com.example.loryblu.ui.components.LBPasswordTextField
 import com.example.loryblu.ui.components.LBTitle
 import com.example.loryblu.ui.theme.Error
 import com.example.loryblu.util.P_SMALL
-import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -103,7 +102,7 @@ fun GuardianRegisterScreen(
                onButtonClick = {
                    passwordHidden = !passwordHidden
                },
-               labelRes = R.string.password,
+               labelRes = stringResource(id = R.string.password),
                value = uiState.password,
                hidden = passwordHidden
            )
@@ -180,7 +179,7 @@ fun GuardianRegisterScreen(
                    }
                },
                onButtonClick = { passwordHidden = !passwordHidden },
-               labelRes = R.string.confirm_password,
+               labelRes = stringResource(id = R.string.confirm_password),
                value = uiState.confirmationPassword,
                hidden = passwordHidden
            )

--- a/app/src/main/java/com/example/loryblu/register/guardian/GuardianRegisterViewModel.kt
+++ b/app/src/main/java/com/example/loryblu/register/guardian/GuardianRegisterViewModel.kt
@@ -3,6 +3,7 @@ package com.example.loryblu.register.guardian
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.loryblu.R
+import com.example.loryblu.login.PasswordInputValid
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -12,6 +13,7 @@ data class GuardianRegisterUiState(
     val email: String = "",
     val password: String = "",
     val confirmationPassword: String = "",
+    val passwordState: PasswordInputValid = PasswordInputValid.Empty,
     val showPassword: Boolean = true,
     val showConfirmationPassword: Boolean = true,
     val passwordHas: Map<Int, Boolean> = mapOf(

--- a/app/src/main/java/com/example/loryblu/ui/components/LBEmailTextField.kt
+++ b/app/src/main/java/com/example/loryblu/ui/components/LBEmailTextField.kt
@@ -31,7 +31,6 @@ fun LBEmailTextField(
             )
         },
         label = { Text(text = labelRes) },
-        textStyle = MaterialTheme.typography.bodyLarge,
         singleLine = true,
         modifier = Modifier.fillMaxWidth(),
         isError = error is EmailInputValid.Error,

--- a/app/src/main/java/com/example/loryblu/ui/components/LBEmailTextField.kt
+++ b/app/src/main/java/com/example/loryblu/ui/components/LBEmailTextField.kt
@@ -1,0 +1,48 @@
+package com.example.loryblu.ui.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import com.example.loryblu.R
+import com.example.loryblu.login.EmailInputValid
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LBEmailTextField(
+    onValueChange: (String) -> Unit,
+    labelRes: String,
+    value: String,
+    error: EmailInputValid,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = { onValueChange(it) },
+        leadingIcon = {
+            Icon(
+                painterResource(id = R.drawable.ic_email),
+                contentDescription = stringResource(R.string.mail_icon)
+            )
+        },
+        label = { Text(text = labelRes) },
+        textStyle = MaterialTheme.typography.bodyLarge,
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+        isError = error is EmailInputValid.Error,
+        supportingText = {
+            if(error is EmailInputValid.Error) {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = stringResource(id = error.messageId),
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/example/loryblu/ui/components/LBPasswordTextField.kt
+++ b/app/src/main/java/com/example/loryblu/ui/components/LBPasswordTextField.kt
@@ -25,7 +25,7 @@ import com.example.loryblu.R
 fun LBPasswordTextField(
     onValueChange: (String) -> Unit,
     onButtonClick: () -> Unit,
-    labelRes: Int,
+    labelRes: String,
     value: String,
     hidden: Boolean
 ) {
@@ -43,7 +43,7 @@ fun LBPasswordTextField(
         onValueChange = { onValueChange(it) },
         singleLine = true,
         label = {
-            Text(text = stringResource(labelRes))
+            Text(text = labelRes)
         },
         trailingIcon = {
             IconButton(onClick = { onButtonClick() }) {

--- a/app/src/main/java/com/example/loryblu/ui/components/LBPasswordTextField.kt
+++ b/app/src/main/java/com/example/loryblu/ui/components/LBPasswordTextField.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import com.example.loryblu.R
-import com.example.loryblu.login.EmailInputValid
 import com.example.loryblu.login.PasswordInputValid
 
 // TODO seek problems in this function

--- a/app/src/main/java/com/example/loryblu/ui/components/LBPasswordTextField.kt
+++ b/app/src/main/java/com/example/loryblu/ui/components/LBPasswordTextField.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -15,6 +16,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import com.example.loryblu.R
+import com.example.loryblu.login.EmailInputValid
+import com.example.loryblu.login.PasswordInputValid
 
 // TODO seek problems in this function
 /**
@@ -27,6 +30,7 @@ fun LBPasswordTextField(
     onButtonClick: () -> Unit,
     labelRes: String,
     value: String,
+    error: PasswordInputValid,
     hidden: Boolean
 ) {
     val visualTransformation =
@@ -58,6 +62,16 @@ fun LBPasswordTextField(
                 painter = painterResource(R.drawable.ic_lock),
                 contentDescription = stringResource(R.string.lock_icon)
             )
+        },
+        isError = error is PasswordInputValid.Error,
+        supportingText = {
+            if(error is PasswordInputValid.Error) {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = stringResource(error.messageId),
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
         },
         modifier = Modifier.fillMaxWidth(),
         visualTransformation = visualTransformation,

--- a/app/src/main/java/com/example/loryblu/ui/components/LBPasswordTextField.kt
+++ b/app/src/main/java/com/example/loryblu/ui/components/LBPasswordTextField.kt
@@ -1,6 +1,7 @@
 package com.example.loryblu.ui.components
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -10,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import com.example.loryblu.R
@@ -25,29 +27,21 @@ fun LBPasswordTextField(
     onButtonClick: () -> Unit,
     labelRes: Int,
     value: String,
-    show: Boolean
+    hidden: Boolean
 ) {
     val visualTransformation =
-        if (show)
-            VisualTransformation.None
-        else
-            PasswordVisualTransformation('*')
+        if (hidden) PasswordVisualTransformation() else VisualTransformation.None
 
     val trailingIconRes =
-        if (show)
-            R.drawable.ic_eye_open
-        else
-            R.drawable.ic_eye_close
+        if (hidden) R.drawable.ic_eye_close else R.drawable.ic_eye_open
 
     val trailingDescriptionRes =
-        if (show)
-            R.string.open_eye
-        else
-            R.string.close_eye
+        if (hidden) R.string.close_eye else R.string.open_eye
 
     OutlinedTextField(
         value = value,
         onValueChange = { onValueChange(it) },
+        singleLine = true,
         label = {
             Text(text = stringResource(labelRes))
         },
@@ -66,6 +60,7 @@ fun LBPasswordTextField(
             )
         },
         modifier = Modifier.fillMaxWidth(),
-        visualTransformation = visualTransformation
-    )
+        visualTransformation = visualTransformation,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+        )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,7 +16,6 @@
     <string name="invalid_e_mail">*Invalid E-mail</string>
     <string name="required_field">*Required field</string>
     <string name="empty_email">*Empty email</string>
-    <string name="empty_string"></string>
     <string name="kid_register">Register Kid</string>
     <string name="guardian_registration">Guardian Registration</string>
     <string name="don_t_have_an_account">Don\'t have an account?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,4 +42,5 @@
     <string name="warning_about_change_the_password">You will be disconnected from all devices and will need to log in with your new password</string>
     <string name="reset_your_password_here">Reset your password here</string>
     <string name="create_a_new_password">Create a new password</string>
+    <string name="password_is_empty">Password is empty</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <string name="open_eye">Open eye</string>
     <string name="invalid_e_mail">*Invalid E-mail</string>
     <string name="required_field">*Required field</string>
-    <string name="empty_email">*Not found e-mail</string>
+    <string name="empty_email">*Empty email</string>
     <string name="empty_string"></string>
     <string name="kid_register">Register Kid</string>
     <string name="guardian_registration">Guardian Registration</string>


### PR DESCRIPTION
- Agora a senha começa escondida, e o botão de esconder está funcionando
- Tirando algumas responsabilidades que estavam no viewmodel para a tela, como deveria ser
- Mudanças na validação do email e da senha para um código mais limpo, e utilizando a biblioteca Patterns do Android
- Pequenos ajustes da tela de login para se parecerem mais como no Figma
- Botões de "Esqueceu a senha" e "Criar conta" agora são clicáveis e redirecionam para suas respectivas telas
- Botão avançar na tela de login avança a tela apenas quando o campo de email e senha forem válidos
- Alguns ajustes para um código mais limpo, legível e seguindo as boas práticas

Apesar de algumas mudanças em outros arquivos esse branch serve exclusivamente com o propósito de corrigir a tela de login, outras telas passarão por revisão e ajustes de navegação ainda