### PR TITLE
LOR 99 - Validação dos componentes

### DIFF
--- a/app/src/main/java/com/example/loryblu/forgotpassword/ForgotPasswordScreen.kt
+++ b/app/src/main/java/com/example/loryblu/forgotpassword/ForgotPasswordScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -22,6 +24,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.loryblu.R
 import com.example.loryblu.ui.components.LBButton
 import com.example.loryblu.ui.components.LBEmailTextField
+import com.example.loryblu.ui.components.LBSuccessLabel
 import com.example.loryblu.ui.components.LBTitle
 import com.example.loryblu.util.P_MEDIUM
 import com.example.loryblu.util.P_SMALL
@@ -31,9 +34,11 @@ import com.example.loryblu.util.P_SMALL
 fun ForgotPasswordScreen(
     viewModel: ForgotPasswordViewModel,
     authenticated: Boolean,
+    sendEmailSuccess: Boolean,
     navigateToCreatePasswordScreen: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val showSuccessLabel = remember { mutableStateOf(false) }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Top,
@@ -55,7 +60,7 @@ fun ForgotPasswordScreen(
         LBEmailTextField(
             onValueChange = { email: String ->
                 viewModel.updateEmail(email)
-                viewModel.emailState(email = email)
+                viewModel.emailState()
             },
             labelRes = stringResource(id = R.string.email),
             value = uiState.email,
@@ -70,12 +75,25 @@ fun ForgotPasswordScreen(
                 viewModel.sendEmail()
             }, modifier = Modifier
         )
+
+        if(showSuccessLabel.value) {
+            LBSuccessLabel(
+                labelRes = stringResource(R.string.send_email_successfully)
+            )
+        }
     }
 
     LaunchedEffect(key1 = authenticated) {
         if(authenticated) {
-            Log.d("ForgotPasswordScreen", "Navigate to next screen")
+            Log.d("ForgotPasswordScreen", "Navigate to create password screen")
             navigateToCreatePasswordScreen()
+        }
+    }
+
+    LaunchedEffect(key1 = sendEmailSuccess) {
+        if(sendEmailSuccess) {
+            Log.d("ForgotPasswordScreen", "Showing that email has been send successfully")
+            showSuccessLabel.value = true
         }
     }
 }
@@ -84,5 +102,5 @@ fun ForgotPasswordScreen(
 @Composable
 @Preview
 fun PreviewForgotScreen() {
-    ForgotPasswordScreen(viewModel = ForgotPasswordViewModel(), authenticated = false, navigateToCreatePasswordScreen = {})
+    ForgotPasswordScreen(viewModel = ForgotPasswordViewModel(), authenticated = false, sendEmailSuccess = true, navigateToCreatePasswordScreen = {})
 }

--- a/app/src/main/java/com/example/loryblu/forgotpassword/ForgotPasswordViewModel.kt
+++ b/app/src/main/java/com/example/loryblu/forgotpassword/ForgotPasswordViewModel.kt
@@ -23,13 +23,17 @@ class ForgotPasswordViewModel: ViewModel() {
     var authenticated = mutableStateOf(false)
         private set
 
+    var sendEmailSuccess = mutableStateOf(false)
+        private set
+
     fun updateEmail(newEmail: String) {
         _uiState.update {
             it.copy(email = newEmail)
         }
     }
 
-    fun emailState(email: String) {
+    fun emailState() {
+        val email = uiState.value.email
         when {
             email.isEmpty() -> {
                 _uiState.update {
@@ -60,10 +64,13 @@ class ForgotPasswordViewModel: ViewModel() {
 
     fun sendEmail() {
         // TODO Aqui será feita a requição para a db com o email passado
-        // Caso de certo redirecione para o createPassword
-        viewModelScope.launch {
-            delay(3000)
-            if(uiState.value.emailState is EmailInputValid.Valid) {
+
+        emailState()
+        if(uiState.value.emailState is EmailInputValid.Valid) {
+            viewModelScope.launch {
+                delay(1000)
+                sendEmailSuccess.value = true
+                delay(5000)
                 authenticated.value = true
             }
         }

--- a/app/src/main/java/com/example/loryblu/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/loryblu/navigation/NavGraph.kt
@@ -111,11 +111,13 @@ fun NavGraphBuilder.forgotPasswordRoute(
     composable(route = Screen.ForgetPassword.route) {
         val viewModel: ForgotPasswordViewModel = viewModel()
         val authenticated by viewModel.authenticated
+        val sendEmailSuccess by viewModel.sendEmailSuccess
 
         ForgotPasswordScreen(
             viewModel = viewModel,
             authenticated = authenticated,
-            navigateToCreatePasswordScreen = navigateToCreatePassword
+            sendEmailSuccess = sendEmailSuccess,
+            navigateToCreatePasswordScreen = navigateToCreatePassword,
         )
     }
 }

--- a/app/src/main/java/com/example/loryblu/ui/components/LBSuccessLabel.kt
+++ b/app/src/main/java/com/example/loryblu/ui/components/LBSuccessLabel.kt
@@ -1,0 +1,38 @@
+package com.example.loryblu.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+
+@Composable
+fun LBSuccessLabel(
+    labelRes: String,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth()
+            .padding(15.dp),
+        horizontalAlignment = Alignment.End,
+    ) {
+        Text(
+            text = labelRes,
+            fontWeight = FontWeight.Bold,
+            fontSize = MaterialTheme.typography.bodyMedium.fontSize,
+        )
+    }
+}
+
+@Preview
+@Composable
+fun LbSuccessLabel() {
+    
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,5 @@
     <string name="reset_your_password_here">Reset your password here</string>
     <string name="create_a_new_password">Create a new password</string>
     <string name="password_is_empty">Password is empty</string>
+    <string name="send_email_successfully">Send email successfully</string>
 </resources>


### PR DESCRIPTION
- Botão de voltar volta para o login

- Campo inválido: texto vermelho abaixo do campo
- Caso o campo de email esteja inválido e o usuário aperte enviar não vá para a próxima tela
- O campo deverá passar novamente por verificação ao apertar o botão de enviar
- Caso tudo esteja correto aparecer que o email para resetar a senha foi enviado com sucesso (em testes isso irá aparecer 1s após o usuário clicar no botão)
- No momento caso esteja certo ele vai para o create password após 5s, porém em cenário real a tela continuará a mesma, e o usuário deverá acessar por meio de email a tela para criar nova senha (em testes isso irá aparecer 6s após o usuário clicar no botão)
