### PR TITLE
:sparkles: feat: Task resume layout

### DIFF
--- a/core/ui/src/main/java/com/loryblu/core/ui/components/LBProgressBar.kt
+++ b/core/ui/src/main/java/com/loryblu/core/ui/components/LBProgressBar.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
@@ -43,7 +42,7 @@ fun LBProgressBar(modifier: Modifier = Modifier, currentStep: Int) {
             for (step in 1..totalSteps) {
                 ProgressCircle(step = step, currentStep = currentStep)
                 if (step < totalSteps) {
-                    ProgressLine(step = step, currentStep = currentStep, lineWidth = 55f)
+                    ProgressLine(step = step, currentStep = currentStep, lineWidth = 44f)
                 }
             }
         }

--- a/core/util/src/main/java/com/loryblu/core/util/Screen.kt
+++ b/core/util/src/main/java/com/loryblu/core/util/Screen.kt
@@ -17,4 +17,5 @@ sealed class Screen(val route: String) {
     data object CategoryScreen: Screen(route = "category_screen")
     data object TaskScreen: Screen(route = "task_screen")
     data object ShiftScreen: Screen(route = "shift_screen")
+    data object SummaryScreen: Screen(route = "summary_screen")
 }

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/di/logbookModule.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/di/logbookModule.kt
@@ -3,11 +3,16 @@ package com.loryblu.feature.logbook.di
 import com.loryblu.feature.logbook.ui.task.LogbookTaskViewModel
 import com.loryblu.feature.logbook.model.Category
 import com.loryblu.feature.logbook.model.LogbookTaskModel
+import com.loryblu.feature.logbook.ui.home.LogbookHomeViewModel
+import com.loryblu.feature.logbook.useCases.GetUserTaskByDayOfWeek
+import com.loryblu.feature.logbook.useCases.GetUserTaskByDayOfWeekImpl
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val logbookModule = module {
     viewModel { LogbookTaskViewModel(get(), get(), get()) }
+    viewModel { LogbookHomeViewModel(get())}
 
+    single<GetUserTaskByDayOfWeek> { GetUserTaskByDayOfWeekImpl(get()) }
     single<LogbookTaskModel> { LogbookTaskModel(Category.ROUTINE, "", "", listOf()) }
 }

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/model/LogbookTaskModel.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/model/LogbookTaskModel.kt
@@ -7,7 +7,7 @@ data class LogbookTaskModel(
     var frequency: List<String>
 )
 
-enum class Category{
-    ROUTINE,
-    STUDIOUS
+enum class Category(val action:String) {
+    ROUTINE("LoryRotina"),
+    STUDIOUS("LoryEstudioso")
 }

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/navigation/LogbookNavigation.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/navigation/LogbookNavigation.kt
@@ -12,6 +12,7 @@ import com.loryblu.feature.logbook.ui.home.LogbookScreen
 import com.loryblu.feature.logbook.ui.task.ShiftScreen
 import com.loryblu.feature.logbook.ui.task.TaskScreen
 import com.loryblu.feature.logbook.ui.home.LogbookHomeViewModel
+import com.loryblu.feature.logbook.ui.task.SummaryScreen
 import org.koin.androidx.compose.koinViewModel
 
 fun NavGraphBuilder.logbookNavigation(
@@ -83,11 +84,7 @@ fun NavGraphBuilder.logbookNavigation(
                     onNextScreenClicked = { shift, frequency ->
                         viewModel.setShift(shift)
                         viewModel.setFrequency(frequency)
-                        viewModel.createLogbookTask()
-                        navController.navigate(Screen.Logbook.route) {
-                            launchSingleTop = true
-                            popUpTo(Screen.Logbook.route) { inclusive = true }
-                        }
+                        navController.navigate(Screen.SummaryScreen.route)
                     },
                     onCloseButtonClicked = {
                         navController.navigate(Screen.Logbook.route) {
@@ -96,6 +93,17 @@ fun NavGraphBuilder.logbookNavigation(
                         }
                     },
                 )
+            }
+
+            composable(route = Screen.SummaryScreen.route) {
+                val viewModel: LogbookTaskViewModel = koinViewModel()
+
+                SummaryScreen(
+                    onBackButtonClicked = { /*TODO*/ },
+                    onCloseButtonClicked = { /*TODO*/ },
+                    logbookTaskModel = viewModel.getLogbookTaskModel()
+                ) {
+                }
             }
         }
     }

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/LogbookTaskViewModel.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/LogbookTaskViewModel.kt
@@ -30,6 +30,8 @@ class LogbookTaskViewModel(
         logbookTaskModel.frequency = frequency
     }
 
+    fun getLogbookTaskModel() : LogbookTaskModel = logbookTaskModel
+
     fun createLogbookTask() = viewModelScope.launch {
         val childId = session.getChildId()
         val logbookRequest = LogbookTaskRequest(

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/SummaryScreen.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/SummaryScreen.kt
@@ -1,0 +1,327 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.loryblu.feature.logbook.ui.task
+
+import LBProgressBar
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.loryblu.core.ui.components.LBButton
+import com.loryblu.core.ui.components.LBTaskCard
+import com.loryblu.core.ui.components.LBTopAppBar
+import com.loryblu.core.ui.theme.LBDarkBlue
+import com.loryblu.core.ui.theme.LBLightGray
+import com.loryblu.core.ui.theme.LBShadowGray
+import com.loryblu.core.ui.theme.LBSkyBlue
+import com.loryblu.data.logbook.local.RoutineTaskItem
+import com.loryblu.data.logbook.local.getAllRoutineItems
+import com.loryblu.data.logbook.local.getAllShiftItems
+import com.loryblu.feature.home.R
+import com.loryblu.feature.logbook.model.Category
+import com.loryblu.feature.logbook.model.LogbookTaskModel
+import com.loryblu.feature.logbook.ui.components.FrequencyBar
+import com.loryblu.feature.logbook.ui.components.ShiftBar
+
+@Composable
+fun SummaryScreen(
+    onBackButtonClicked: () -> Unit,
+    onCloseButtonClicked: () -> Unit,
+    logbookTaskModel: LogbookTaskModel,
+    onNextScreenClicked: () -> Unit,
+) {
+
+    val shiftSelected = getShiftSelected(logbookTaskModel.shift)
+    val selectedDay = getDaySelected(logbookTaskModel.frequency)
+
+    Scaffold(
+        topBar = {
+            LBTopAppBar(
+                title = stringResource(R.string.logbook_title),
+                onBackClicked = onBackButtonClicked,
+                onCloseClicked = onCloseButtonClicked,
+                showCloseButton = true
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(24.dp), horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                LBProgressBar(modifier = Modifier.fillMaxWidth(), currentStep = 4)
+                Spacer(modifier = Modifier.size(8.dp))
+                getTask(taskId = logbookTaskModel.task)?.let { taskItem ->
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn()
+                    ) {
+                        val painter = painterResource(taskItem.drawable)
+                        Spacer(Modifier.weight(0.25f))
+                        LBTaskCard(
+                            card = taskItem,
+                            modifier = Modifier
+                                .size(150.dp)
+                                .aspectRatio(painter.intrinsicSize.width / painter.intrinsicSize.height)
+                                .fillMaxWidth(),
+                            selected = true,
+                            onclick = { })
+                        Spacer(Modifier.weight(0.25f))
+                    }
+                    Spacer(modifier = Modifier.size(8.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(start = 24.dp),
+                            text = stringResource(R.string.categoryTitle),
+                            style = TextStyle(
+                                fontSize = 20.sp,
+                                lineHeight = 24.sp,
+                                fontWeight = FontWeight(500),
+                                color = Color.Black,
+                                textAlign = TextAlign.Start,
+                            )
+                        )
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .clip(RoundedCornerShape(8.dp))
+                                .background(LBDarkBlue)
+                        ) {
+                            Text(
+                                modifier = Modifier
+                                    .padding(8.dp)
+                                    .align(Alignment.Center),
+                                text = stringResource(id = taskItem.text),
+                                style = TextStyle(
+                                    fontSize = 20.sp,
+                                    lineHeight = 24.sp,
+                                    fontWeight = FontWeight(500),
+                                    color = Color.White,
+                                    textAlign = TextAlign.Center,
+                                )
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.size(8.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(start = 24.dp), text = stringResource(R.string.taskTitle), style = TextStyle(
+                                fontSize = 20.sp,
+                                lineHeight = 16.sp,
+                                fontWeight = FontWeight(500),
+                                color = Color.Black,
+                                textAlign = TextAlign.Start,
+                            )
+                        )
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .clip(RoundedCornerShape(8.dp))
+                                .background(LBDarkBlue)
+                        )
+                        {
+                            Text(
+                                modifier = Modifier
+                                    .padding(8.dp)
+                                    .align(Alignment.Center),
+                                text = logbookTaskModel.category.action,
+                                style = TextStyle(
+                                    fontSize = 20.sp,
+                                    lineHeight = 16.sp,
+                                    fontWeight = FontWeight(500),
+                                    color = Color.White,
+                                    textAlign = TextAlign.Center,
+                                )
+                            )
+                        }
+                    }
+                }
+                HorizontalDivider(
+                    modifier = Modifier
+                        .padding(top = 24.dp, bottom = 24.dp)
+                        .drawWithContent {
+                            drawContent()
+                            drawLine(
+                                color = LBLightGray,
+                                start = Offset(0.dp.toPx(), size.height / 2),
+                                end = Offset(size.width, size.height / 2),
+                                strokeWidth = 2.dp.toPx(),
+                                cap = StrokeCap.Round
+                            )
+                        }
+                        .graphicsLayer(clip = true),
+                    thickness = 2.dp
+                )
+
+                Text(
+                    modifier = Modifier.align(Alignment.Start),
+                    text = stringResource(R.string.shiftTitle), style = TextStyle(
+                        fontSize = 20.sp,
+                        lineHeight = 24.sp,
+                        fontWeight = FontWeight(500),
+                        color = Color.Black,
+                        textAlign = TextAlign.Start,
+                    )
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                ShiftBar(
+                    modifier = Modifier.fillMaxWidth(),
+                    shiftSelected = shiftSelected,
+                    onShiftChange = { },
+                    options = getAllShiftItems()
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                Text(
+                    style = TextStyle(
+                        fontSize = 20.sp,
+                        lineHeight = 24.sp,
+                        fontWeight = FontWeight(500),
+                        color = Color.Black,
+                        textAlign = TextAlign.Start,
+                    ), modifier = Modifier
+                        .padding(bottom = 4.dp)
+                        .align(Alignment.Start),
+                    text = stringResource(R.string.frequencyTitle)
+                )
+                Text(
+                    modifier = Modifier.align(Alignment.Start),
+                    text = stringResource(id = R.string.select_a_frequency_description),
+                    style = TextStyle(
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight(500),
+                        color = Color.Black,
+                        textAlign = TextAlign.Start,
+                    )
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                FrequencyBar(selectedDay = selectedDay, onDayClicked = { })
+            }
+            Box(modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(24.dp)) {
+                LBButton(
+                    textRes = R.string.registerTask,
+                    onClick = {
+                    },
+                    buttonColors = ButtonDefaults.buttonColors(
+                        disabledContainerColor = LBLightGray,
+                        containerColor = LBSkyBlue
+                    ),
+                    textColor = Color.White,
+                    areAllFieldsValid = true
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun getTask(taskId: String): RoutineTaskItem? {
+    val tasks = getAllRoutineItems()
+    val task = tasks.find {
+        it.taskId == taskId
+    }
+    return task
+}
+
+@Composable
+private fun getShiftSelected(shift: String): Int {
+    return when (shift) {
+        "morning" -> {
+            0
+        }
+
+        "afternoon" -> {
+            1
+        }
+
+        else -> {
+            2
+        }
+    }
+}
+
+@Composable
+private fun getDaySelected(days: List<String>): List<Int> {
+    val selectedDays = remember { mutableStateListOf<Int>() }
+    val nameOfWeekDays = arrayOf("sun", "mon", "tue", "wed", "thu", "fri", "sat")
+    nameOfWeekDays.forEachIndexed { index, day ->
+        if (days.any { it.contains(day) }) {
+            selectedDays.add(index)
+        }
+    }
+    return selectedDays
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SummaryPreview() {
+    SummaryScreen(
+        onBackButtonClicked = { },
+        onCloseButtonClicked = { },
+        logbookTaskModel = LogbookTaskModel(
+            category = Category.ROUTINE,
+            task = "6dfc15bb-f422-4c75-b2cc-bf3e9806c76a",
+            shift = "morning",
+            frequency = listOf("sun", "mon")
+        ),
+        onNextScreenClicked = { },
+    )
+}

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/SummaryScreen.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/SummaryScreen.kt
@@ -3,9 +3,11 @@
 package com.loryblu.feature.logbook.ui.task
 
 import LBProgressBar
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,12 +21,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
@@ -40,12 +45,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -57,10 +64,12 @@ import androidx.compose.ui.unit.sp
 import com.loryblu.core.ui.components.LBButton
 import com.loryblu.core.ui.components.LBTaskCard
 import com.loryblu.core.ui.components.LBTopAppBar
+import com.loryblu.core.ui.theme.LBCardSoftBlue
 import com.loryblu.core.ui.theme.LBDarkBlue
 import com.loryblu.core.ui.theme.LBLightGray
 import com.loryblu.core.ui.theme.LBShadowGray
 import com.loryblu.core.ui.theme.LBSkyBlue
+import com.loryblu.core.ui.theme.LBSoftBlue
 import com.loryblu.data.logbook.local.RoutineTaskItem
 import com.loryblu.data.logbook.local.getAllRoutineItems
 import com.loryblu.data.logbook.local.getAllShiftItems
@@ -106,20 +115,27 @@ fun SummaryScreen(
                 getTask(taskId = logbookTaskModel.task)?.let { taskItem ->
                     Row(
                         Modifier
-                            .fillMaxWidth()
-                            .heightIn()
+                            .fillMaxWidth().padding(16.dp)
                     ) {
-                        val painter = painterResource(taskItem.drawable)
-                        Spacer(Modifier.weight(0.25f))
-                        LBTaskCard(
-                            card = taskItem,
-                            modifier = Modifier
-                                .size(150.dp)
-                                .aspectRatio(painter.intrinsicSize.width / painter.intrinsicSize.height)
-                                .fillMaxWidth(),
-                            selected = true,
-                            onclick = { })
-                        Spacer(Modifier.weight(0.25f))
+                        Spacer(Modifier.weight(1f))
+                        OutlinedCard(
+                            colors = CardDefaults.cardColors(
+                                containerColor = LBCardSoftBlue,
+                            ),
+                            border = BorderStroke(4.dp, LBDarkBlue),
+                            shape = RoundedCornerShape(5),
+                        ) {
+                            Image(
+                                alignment = Alignment.TopCenter,
+                                modifier = Modifier
+                                    .padding(4.dp)
+                                    .alpha(1f),
+                                painter = painterResource(id = taskItem.drawable),
+                                contentDescription = stringResource(id = taskItem.text),
+                                contentScale = ContentScale.Fit,
+                            )
+                        }
+                        Spacer(Modifier.weight(1f))
                     }
                     Spacer(modifier = Modifier.size(8.dp))
                     Row(verticalAlignment = Alignment.CenterVertically) {
@@ -146,7 +162,7 @@ fun SummaryScreen(
                                 modifier = Modifier
                                     .padding(8.dp)
                                     .align(Alignment.Center),
-                                text = stringResource(id = taskItem.text),
+                                text = logbookTaskModel.category.action,
                                 style = TextStyle(
                                     fontSize = 20.sp,
                                     lineHeight = 24.sp,
@@ -181,7 +197,7 @@ fun SummaryScreen(
                                 modifier = Modifier
                                     .padding(8.dp)
                                     .align(Alignment.Center),
-                                text = logbookTaskModel.category.action,
+                                text = stringResource(id = taskItem.text),
                                 style = TextStyle(
                                     fontSize = 20.sp,
                                     lineHeight = 16.sp,
@@ -252,6 +268,7 @@ fun SummaryScreen(
                 )
                 Spacer(modifier = Modifier.size(8.dp))
                 FrequencyBar(selectedDay = selectedDay, onDayClicked = { })
+                Spacer(Modifier.weight(1f))
             }
             Box(modifier = Modifier
                 .align(Alignment.BottomCenter)

--- a/feature/logbook/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/logbook/src/main/res/values-pt-rBR/strings.xml
@@ -14,4 +14,9 @@
     <string name="new_task">NOVA TAREFA</string>
     <string name="next">PRÓXIMO</string>
     <string name="confirm">CONFIRMAR</string>
+    <string name="registerTask">CADASTRAR</string>
+    <string name="categoryTitle">Categoria:</string>
+    <string name="taskTitle">Tarefa:</string>
+    <string name="shiftTitle">Turno:</string>
+    <string name="frequencyTitle">Frequência:</string>
 </resources>

--- a/feature/logbook/src/main/res/values/strings.xml
+++ b/feature/logbook/src/main/res/values/strings.xml
@@ -13,4 +13,9 @@
     <string name="new_task">ADD TASK</string>
     <string name="next">NEXT</string>
     <string name="confirm">CONFIRM</string>
+    <string name="registerTask">REGISTER</string>
+    <string name="categoryTitle">Category:</string>
+    <string name="taskTitle">Task:</string>
+    <string name="shiftTitle">Shift:</string>
+    <string name="frequencyTitle">Frequency:</string>
 </resources>


### PR DESCRIPTION
## Task

This pull request refers to task LOR-222

- [x] Summary Screen Layout
- [X] The user could see the summary of the Logbook Flow. 

## Description

Now the user could see the summary of the Logbook Flow.

## Types of changes #

- [X] SummaryLogbookTaskScreen.

## What changed: #

- [X] UI
- [ ] Business rule
- [ ] Documentation
- [ ] Gradle or Build
- [X] Navigation
- [ ] Tests
- [X] Resource files
- [ ] Project architecture
- [ ] Code style

## Checklist #

- [X] Have tested the changes.
- [X] Met all the acceptance requirements of this task.
- [X] Verified if branch is up-to-date with `development` (if not - rebase it or merge it).
- [X] Resolve git conflicts

## If any of the acceptance criteria are not met, please explain why below #
What is the criteria? Why it is different?
