### PR TITLE
:sparkles: feat: Task resume navigation

### DIFF
--- a/core/network/src/main/java/com/loryblu/core/network/model/ApiResponseWithData.kt
+++ b/core/network/src/main/java/com/loryblu/core/network/model/ApiResponseWithData.kt
@@ -1,0 +1,10 @@
+package com.loryblu.core.network.model
+
+sealed class ApiResponseWithData<T>(val data: T? = null){
+    class Success<T>(result: T) : ApiResponseWithData<T>(data = result)
+    class Error<T> : ApiResponseWithData<T>()
+    class DefaultError<T> : ApiResponseWithData<T>()
+    class Loading<T> : ApiResponseWithData<T>()
+    class EmptyData<T> : ApiResponseWithData<T>()
+    class Default<T> : ApiResponseWithData<T>()
+}

--- a/core/ui/src/main/java/com/loryblu/core/ui/components/LBProgressBar.kt
+++ b/core/ui/src/main/java/com/loryblu/core/ui/components/LBProgressBar.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
@@ -43,7 +42,7 @@ fun LBProgressBar(modifier: Modifier = Modifier, currentStep: Int) {
             for (step in 1..totalSteps) {
                 ProgressCircle(step = step, currentStep = currentStep)
                 if (step < totalSteps) {
-                    ProgressLine(step = step, currentStep = currentStep, lineWidth = 55f)
+                    ProgressLine(step = step, currentStep = currentStep, lineWidth = 44f)
                 }
             }
         }

--- a/core/util/src/main/java/com/loryblu/core/util/Screen.kt
+++ b/core/util/src/main/java/com/loryblu/core/util/Screen.kt
@@ -17,4 +17,5 @@ sealed class Screen(val route: String) {
     data object CategoryScreen: Screen(route = "category_screen")
     data object TaskScreen: Screen(route = "task_screen")
     data object ShiftScreen: Screen(route = "shift_screen")
+    data object SummaryScreen: Screen(route = "summary_screen")
 }

--- a/data/logbook/src/main/java/com/loryblu/data/logbook/local/LogbookItem.kt
+++ b/data/logbook/src/main/java/com/loryblu/data/logbook/local/LogbookItem.kt
@@ -1,8 +1,12 @@
 package com.loryblu.data.logbook.local
 
+import androidx.compose.ui.graphics.Color
+
+
 sealed class LogbookItem (
     val idCard: Int,
     val text: Int,
     val drawable: Int,
     val isDisabled: Boolean = false,
+    val color: Color = Color.Unspecified
 )

--- a/data/logbook/src/main/java/com/loryblu/data/logbook/local/ShiftItems.kt
+++ b/data/logbook/src/main/java/com/loryblu/data/logbook/local/ShiftItems.kt
@@ -1,5 +1,6 @@
 package com.loryblu.data.logbook.local
 
+import androidx.compose.ui.graphics.Color
 import com.loryblu.data.logbook.R
 
 typealias ShiftItem = LogbookItem
@@ -7,19 +8,22 @@ typealias ShiftItem = LogbookItem
 class Morning : ShiftItem(
     idCard = 0,
     text = R.string.shift_morning,
-    drawable = R.drawable.shift_morning
+    drawable = R.drawable.shift_morning,
+    color = Color(0XFF97D8FE)
 )
 
 class Afternoon : ShiftItem(
     idCard = 1,
     text = R.string.shift_afternoon,
-    drawable = R.drawable.shift_afternoon
+    drawable = R.drawable.shift_afternoon,
+    color = Color(0XFF2491D0)
 )
 
 class Night : ShiftItem(
     idCard = 2,
     text = R.string.shift_night,
-    drawable = R.drawable.shift_night
+    drawable = R.drawable.shift_night,
+    color = Color(0XFF004A98)
 )
 
 fun getAllShiftItems(): List<ShiftItem>{

--- a/data/logbook/src/main/java/com/loryblu/data/logbook/remote/api/LogbookApi.kt
+++ b/data/logbook/src/main/java/com/loryblu/data/logbook/remote/api/LogbookApi.kt
@@ -1,7 +1,12 @@
 package com.loryblu.data.logbook.remote.api
 
+import com.loryblu.core.network.model.ApiResponseWithData
+import com.loryblu.data.logbook.remote.model.LogbookTask
 import com.loryblu.data.logbook.remote.model.LogbookTaskRequest
+import kotlinx.coroutines.flow.Flow
 
 interface LogbookApi {
     suspend fun createTask(logbookTaskRequest: LogbookTaskRequest)
+
+    suspend fun getUserTasks(): Flow<ApiResponseWithData<List<LogbookTask>>>
 }

--- a/data/logbook/src/main/java/com/loryblu/data/logbook/remote/api/LogbookApiImpl.kt
+++ b/data/logbook/src/main/java/com/loryblu/data/logbook/remote/api/LogbookApiImpl.kt
@@ -2,13 +2,20 @@ package com.loryblu.data.logbook.remote.api
 
 import com.loryblu.core.network.HttpRoutes
 import com.loryblu.core.network.di.Session
+import com.loryblu.core.network.model.ApiResponseWithData
+import com.loryblu.data.logbook.remote.model.LogbookTask
 import com.loryblu.data.logbook.remote.model.LogbookTaskRequest
+import com.loryblu.data.logbook.util.toListOfLogbookTask
 import io.ktor.client.HttpClient
 import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import io.ktor.http.parameters
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 class LogbookApiImpl(
     private val client: HttpClient,
@@ -26,4 +33,28 @@ class LogbookApiImpl(
             throw e
         }
     }
+
+    override suspend fun getUserTasks(): Flow<ApiResponseWithData<List<LogbookTask>>> = flow {
+        val nameOfWeekDays = arrayOf("sun", "mon", "tue", "wed", "thu", "fri", "sat")
+
+        emit(ApiResponseWithData.Loading())
+        try{
+            emit(
+                client.get(HttpRoutes.TASK) {
+                    parameters {
+                        append("childrenId", session.getChildId().toString())
+                        nameOfWeekDays.forEach {
+                            append("frequency", it)
+                        }
+                    }
+                    contentType(ContentType.Application.Json)
+                    bearerAuth(session.getToken())
+                }.toListOfLogbookTask()
+            )
+        } catch (e: Exception) {
+            e.printStackTrace()
+            emit(ApiResponseWithData.Error())
+        }
+    }
+
 }

--- a/data/logbook/src/main/java/com/loryblu/data/logbook/remote/model/LogbookTask.kt
+++ b/data/logbook/src/main/java/com/loryblu/data/logbook/remote/model/LogbookTask.kt
@@ -1,0 +1,11 @@
+package com.loryblu.data.logbook.remote.model
+
+data class LogbookTask(
+    val categoryId: String,
+    val categoryTitle: String,
+    val frequency: List<String>,
+    val id: Int,
+    val order: Int,
+    val shift: String,
+    val updatedAt: String
+)

--- a/data/logbook/src/main/java/com/loryblu/data/logbook/remote/model/LogbookTaskRemote.kt
+++ b/data/logbook/src/main/java/com/loryblu/data/logbook/remote/model/LogbookTaskRemote.kt
@@ -1,0 +1,21 @@
+package com.loryblu.data.logbook.remote.model
+
+data class LogbookTaskRemote(
+    val data: Data,
+    val message: String
+)
+
+data class Data(
+    val count: Int,
+    val routine: List<Routine>
+)
+
+data class Routine(
+    val categoryId: String,
+    val categoryTitle: String,
+    val frequency: List<String>,
+    val id: Int,
+    val order: Int,
+    val shift: String,
+    val updatedAt: String
+)

--- a/data/logbook/src/main/java/com/loryblu/data/logbook/util/RemoteExtensions.kt
+++ b/data/logbook/src/main/java/com/loryblu/data/logbook/util/RemoteExtensions.kt
@@ -1,0 +1,33 @@
+package com.loryblu.data.logbook.util
+
+import com.loryblu.core.network.model.ApiResponseWithData
+import com.loryblu.data.logbook.remote.model.LogbookTask
+import com.loryblu.data.logbook.remote.model.LogbookTaskRemote
+import io.ktor.client.call.body
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+
+suspend fun HttpResponse.toListOfLogbookTask(): ApiResponseWithData<List<LogbookTask>> {
+    return when (this.status) {
+        HttpStatusCode.OK -> {
+            val remote = this.body<LogbookTaskRemote?>() ?: return ApiResponseWithData.EmptyData()
+            return ApiResponseWithData.Success(
+                remote.data.routine.map {
+                    LogbookTask(
+                        categoryId = it.categoryId,
+                        categoryTitle = it.categoryTitle,
+                        frequency = it.frequency,
+                        id = it.id,
+                        order = it.order,
+                        shift = it.shift,
+                        updatedAt = it.updatedAt
+                    )
+                }
+            )
+        }
+
+        else -> {
+            ApiResponseWithData.DefaultError()
+        }
+    }
+}

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/di/logbookModule.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/di/logbookModule.kt
@@ -3,11 +3,16 @@ package com.loryblu.feature.logbook.di
 import com.loryblu.feature.logbook.ui.task.LogbookTaskViewModel
 import com.loryblu.feature.logbook.model.Category
 import com.loryblu.feature.logbook.model.LogbookTaskModel
+import com.loryblu.feature.logbook.ui.home.LogbookHomeViewModel
+import com.loryblu.feature.logbook.useCases.GetUserTaskByDayOfWeek
+import com.loryblu.feature.logbook.useCases.GetUserTaskByDayOfWeekImpl
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val logbookModule = module {
     viewModel { LogbookTaskViewModel(get(), get(), get()) }
+    viewModel { LogbookHomeViewModel(get())}
 
+    single<GetUserTaskByDayOfWeek> { GetUserTaskByDayOfWeekImpl(get()) }
     single<LogbookTaskModel> { LogbookTaskModel(Category.ROUTINE, "", "", listOf()) }
 }

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/di/logbookModule.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/di/logbookModule.kt
@@ -1,13 +1,13 @@
 package com.loryblu.feature.logbook.di
 
-import com.loryblu.feature.logbook.LogbookViewModel
+import com.loryblu.feature.logbook.ui.task.LogbookTaskViewModel
 import com.loryblu.feature.logbook.model.Category
 import com.loryblu.feature.logbook.model.LogbookTaskModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val logbookModule = module {
-    viewModel { LogbookViewModel(get(), get(), get()) }
+    viewModel { LogbookTaskViewModel(get(), get(), get()) }
 
     single<LogbookTaskModel> { LogbookTaskModel(Category.ROUTINE, "", "", listOf()) }
 }

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/model/LogbookTaskModel.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/model/LogbookTaskModel.kt
@@ -7,7 +7,7 @@ data class LogbookTaskModel(
     var frequency: List<String>
 )
 
-enum class Category{
-    ROUTINE,
-    STUDIOUS
+enum class Category(val action:String) {
+    ROUTINE("LoryRotina"),
+    STUDIOUS("LoryEstudioso")
 }

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/navigation/LogbookNavigation.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/navigation/LogbookNavigation.kt
@@ -1,5 +1,6 @@
 package com.loryblu.feature.logbook.navigation
 
+import androidx.compose.runtime.collectAsState
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -7,9 +8,10 @@ import androidx.navigation.compose.navigation
 import com.loryblu.core.util.Screen
 import com.loryblu.feature.logbook.LogbookViewModel
 import com.loryblu.feature.logbook.ui.CategoryScreen
-import com.loryblu.feature.logbook.ui.LogbookScreen
+import com.loryblu.feature.logbook.ui.home.LogbookScreen
 import com.loryblu.feature.logbook.ui.ShiftScreen
 import com.loryblu.feature.logbook.ui.TaskScreen
+import com.loryblu.feature.logbook.ui.home.LogbookHomeViewModel
 import org.koin.androidx.compose.koinViewModel
 
 fun NavGraphBuilder.logbookNavigation(
@@ -21,11 +23,18 @@ fun NavGraphBuilder.logbookNavigation(
         route = "logbook"
     ) {
         composable(route = Screen.Logbook.route) {
+            val viewModel: LogbookHomeViewModel = koinViewModel()
+
+            val userTasks = viewModel.userTasks.collectAsState()
+
             LogbookScreen(
                 onBackButtonClicked = onBackButtonClicked,
                 onNextScreenClicked = {
                     navController.navigate(Screen.CategoryScreen.route)
-                })
+                },
+                userTasks = userTasks.value,
+                selectADayOfWeek = { viewModel.selectADayOfWeek(it) }
+            )
         }
 
         navigation(

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/navigation/LogbookNavigation.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/navigation/LogbookNavigation.kt
@@ -6,11 +6,11 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import com.loryblu.core.util.Screen
-import com.loryblu.feature.logbook.LogbookViewModel
-import com.loryblu.feature.logbook.ui.CategoryScreen
+import com.loryblu.feature.logbook.ui.task.LogbookTaskViewModel
+import com.loryblu.feature.logbook.ui.task.CategoryScreen
 import com.loryblu.feature.logbook.ui.home.LogbookScreen
-import com.loryblu.feature.logbook.ui.ShiftScreen
-import com.loryblu.feature.logbook.ui.TaskScreen
+import com.loryblu.feature.logbook.ui.task.ShiftScreen
+import com.loryblu.feature.logbook.ui.task.TaskScreen
 import com.loryblu.feature.logbook.ui.home.LogbookHomeViewModel
 import org.koin.androidx.compose.koinViewModel
 
@@ -42,7 +42,7 @@ fun NavGraphBuilder.logbookNavigation(
             route = "register_logbook_task"
         ) {
             composable(route = Screen.CategoryScreen.route) {
-                val viewModel: LogbookViewModel = koinViewModel()
+                val viewModel: LogbookTaskViewModel = koinViewModel()
 
                 CategoryScreen(
                     onBackButtonClicked = { navController.popBackStack() },
@@ -59,7 +59,7 @@ fun NavGraphBuilder.logbookNavigation(
             }
 
             composable(route = Screen.TaskScreen.route) {
-                val viewModel: LogbookViewModel = koinViewModel()
+                val viewModel: LogbookTaskViewModel = koinViewModel()
 
                 TaskScreen(
                     onBackButtonClicked = { navController.popBackStack() },
@@ -76,7 +76,7 @@ fun NavGraphBuilder.logbookNavigation(
             }
 
             composable(route = Screen.ShiftScreen.route) {
-                val viewModel: LogbookViewModel = koinViewModel()
+                val viewModel: LogbookTaskViewModel = koinViewModel()
 
                 ShiftScreen(
                     onBackButtonClicked = { navController.popBackStack() },

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/navigation/LogbookNavigation.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/navigation/LogbookNavigation.kt
@@ -30,9 +30,7 @@ fun NavGraphBuilder.logbookNavigation(
 
             LogbookScreen(
                 onBackButtonClicked = onBackButtonClicked,
-                onNextScreenClicked = {
-                    navController.navigate(Screen.CategoryScreen.route)
-                },
+                onNextScreenClicked = { navController.navigate(Screen.CategoryScreen.route) },
                 userTasks = userTasks.value,
                 selectADayOfWeek = { viewModel.selectADayOfWeek(it) }
             )
@@ -46,15 +44,15 @@ fun NavGraphBuilder.logbookNavigation(
                 val viewModel: LogbookTaskViewModel = koinViewModel()
 
                 CategoryScreen(
-                    onBackButtonClicked = { navController.popBackStack() },
+                    onBackButtonClicked = { navController.navigateUp() },
                     onNextScreenClicked = {
                         viewModel.setSelectedCategory(it)
-                        navController.popBackStack()
                         navController.navigate(Screen.TaskScreen.route)
                     },
                     onCloseButtonClicked = {
-                        navController.popBackStack()
-                        navController.navigate(Screen.Logbook.route)
+                        navController.navigate(Screen.Dashboard.route) {
+                            popUpTo(Screen.Logbook.route) { inclusive = true }
+                        }
                     },
                 )
             }
@@ -63,15 +61,15 @@ fun NavGraphBuilder.logbookNavigation(
                 val viewModel: LogbookTaskViewModel = koinViewModel()
 
                 TaskScreen(
-                    onBackButtonClicked = { navController.popBackStack() },
+                    onBackButtonClicked = { navController.navigateUp() },
                     onNextScreenClicked = {
                         viewModel.setSelectedTask(it)
-                        navController.popBackStack()
                         navController.navigate(Screen.ShiftScreen.route)
                     },
                     onCloseButtonClicked = {
-                        navController.popBackStack()
-                        navController.navigate(Screen.Logbook.route)
+                        navController.navigate(Screen.Dashboard.route) {
+                            popUpTo(Screen.Logbook.route) { inclusive = true }
+                        }
                     },
                 )
             }
@@ -80,15 +78,14 @@ fun NavGraphBuilder.logbookNavigation(
                 val viewModel: LogbookTaskViewModel = koinViewModel()
 
                 ShiftScreen(
-                    onBackButtonClicked = { navController.popBackStack() },
+                    onBackButtonClicked = { navController.navigateUp() },
                     onNextScreenClicked = { shift, frequency ->
                         viewModel.setShift(shift)
                         viewModel.setFrequency(frequency)
                         navController.navigate(Screen.SummaryScreen.route)
                     },
                     onCloseButtonClicked = {
-                        navController.navigate(Screen.Logbook.route) {
-                            launchSingleTop = true
+                        navController.navigate(Screen.Dashboard.route) {
                             popUpTo(Screen.Logbook.route) { inclusive = true }
                         }
                     },
@@ -99,8 +96,16 @@ fun NavGraphBuilder.logbookNavigation(
                 val viewModel: LogbookTaskViewModel = koinViewModel()
 
                 SummaryScreen(
-                    onBackButtonClicked = { /*TODO*/ },
-                    onCloseButtonClicked = { /*TODO*/ },
+                    onBackButtonClicked = {
+                        navController.navigate(Screen.Logbook.route) {
+                            popUpTo(Screen.Logbook.route) { inclusive = true }
+                        }
+                    },
+                    onCloseButtonClicked = {
+                        navController.navigate(Screen.Dashboard.route) {
+                            popUpTo(Screen.Logbook.route) { inclusive = true }
+                        }
+                    },
                     logbookTaskModel = viewModel.getLogbookTaskModel()
                 ) {
                 }

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/navigation/LogbookNavigation.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/navigation/LogbookNavigation.kt
@@ -12,6 +12,7 @@ import com.loryblu.feature.logbook.ui.home.LogbookScreen
 import com.loryblu.feature.logbook.ui.task.ShiftScreen
 import com.loryblu.feature.logbook.ui.task.TaskScreen
 import com.loryblu.feature.logbook.ui.home.LogbookHomeViewModel
+import com.loryblu.feature.logbook.ui.task.SummaryScreen
 import org.koin.androidx.compose.koinViewModel
 
 fun NavGraphBuilder.logbookNavigation(
@@ -83,11 +84,7 @@ fun NavGraphBuilder.logbookNavigation(
                     onNextScreenClicked = { shift, frequency ->
                         viewModel.setShift(shift)
                         viewModel.setFrequency(frequency)
-                        viewModel.createLogbookTask()
-                        navController.navigate(Screen.Logbook.route) {
-                            launchSingleTop = true
-                            popUpTo(Screen.Logbook.route) { inclusive = true }
-                        }
+                        navController.navigate(Screen.SummaryScreen.route)
                     },
                     onCloseButtonClicked = {
                         navController.navigate(Screen.Logbook.route) {
@@ -96,6 +93,17 @@ fun NavGraphBuilder.logbookNavigation(
                         }
                     },
                 )
+            }
+
+            composable(route = Screen.SummaryScreen.route) {
+                val viewModel: LogbookTaskViewModel = koinViewModel()
+
+                SummaryScreen(
+                    onBackButtonClicked = { /*TODO*/ },
+                    onCloseButtonClicked = { /*TODO*/ },
+                    logbookTaskModel = viewModel.getLogbookTaskModel()
+                ) {
+                }
             }
         }
     }

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/components/FrequencyBar.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/components/FrequencyBar.kt
@@ -29,8 +29,8 @@ fun FrequencyBar(
     val daysOfWeek = getInitialDaysOfWeek()
     Row(
         modifier = modifier
-            .background(LBFrequencyBackgroundBlue, shape = RoundedCornerShape(16))
-            .padding(horizontal = 4.dp, vertical = 8.dp),
+            .padding(horizontal = 4.dp, vertical = 4.dp)
+            .background(LBFrequencyBackgroundBlue, shape = RoundedCornerShape(16)),
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         daysOfWeek.forEachIndexed { index, day ->

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/components/ShiftBar.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/components/ShiftBar.kt
@@ -1,0 +1,85 @@
+package com.loryblu.feature.logbook.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonBorder
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.loryblu.data.logbook.local.ShiftItem
+import com.loryblu.data.logbook.local.getAllShiftItems
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ShiftBar(
+    modifier: Modifier = Modifier,
+    shiftSelected: Int,
+    onShiftChange: (Int) -> Unit,
+    options: List<ShiftItem>
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        SingleChoiceSegmentedButtonRow(modifier.fillMaxWidth()) {
+            options.forEachIndexed { index, shift ->
+                SegmentedButton(
+                    shape = SegmentedButtonDefaults.itemShape(
+                        index = index,
+                        count = options.size,
+                        baseShape = RoundedCornerShape(8.dp)
+                    ),
+                    onClick = { onShiftChange(index) },
+                    selected = index == shiftSelected,
+                    colors = SegmentedButtonDefaults.colors(
+                        activeContainerColor = shift.color,
+                        inactiveContainerColor = Color(0XFFE8EAFD),
+                        activeBorderColor = Color.Transparent,
+                    ),
+                    icon = {
+                        SegmentedButtonDefaults.Icon(
+                            active = shiftSelected == index,
+                            activeContent = {
+                                Icon(
+                                    painter = painterResource(id = shift.drawable),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(SegmentedButtonDefaults.IconSize),
+                                    tint = Color.Unspecified
+                                )
+                            }
+                        )
+                    },
+                ) {
+                    Text(stringResource(id = shift.text))
+                }
+            }
+
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ShiftBarPrev() {
+    ShiftBar(
+        shiftSelected = 1,
+        onShiftChange = {},
+        options = getAllShiftItems()
+    )
+}

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/home/LogbookHomeViewModel.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/home/LogbookHomeViewModel.kt
@@ -1,0 +1,27 @@
+package com.loryblu.feature.logbook.ui.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.loryblu.core.network.model.ApiResponseWithData
+import com.loryblu.data.logbook.remote.model.LogbookTask
+import com.loryblu.feature.logbook.useCases.GetUserTaskByDayOfWeek
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class LogbookHomeViewModel(
+    private val getUserTaskByDayOfWeek: GetUserTaskByDayOfWeek
+): ViewModel() {
+
+    private val _userTasks = MutableStateFlow<ApiResponseWithData<List<LogbookTask>>>(ApiResponseWithData.Default())
+    val userTasks: StateFlow<ApiResponseWithData<List<LogbookTask>>> = _userTasks
+
+    fun selectADayOfWeek(dayOfWeekInt: Int) = viewModelScope.launch {
+        val nameOfWeekDays = arrayOf("sun", "mon", "tue", "wed", "thu", "fri", "sat")
+        val dayOfWeek = nameOfWeekDays[dayOfWeekInt + 1]
+
+        getUserTaskByDayOfWeek.invoke(dayOfWeek).collect {
+            _userTasks.value = it
+        }
+    }
+}

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/home/LogbookScreen.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/home/LogbookScreen.kt
@@ -67,7 +67,7 @@ fun LogbookScreen(
                 title = stringResource(R.string.logbook_title),
                 onBackClicked = { onBackButtonClicked() },
                 onCloseClicked = { onBackButtonClicked() },
-                showCloseButton = true
+                showCloseButton = false
             )
         },
         content = { innerPadding ->

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/home/LogbookScreen.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/home/LogbookScreen.kt
@@ -2,7 +2,9 @@ package com.loryblu.feature.logbook.ui.home
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,6 +22,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ShapeDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -33,8 +38,11 @@ import androidx.compose.ui.unit.sp
 import com.loryblu.core.network.model.ApiResponseWithData
 import com.loryblu.core.ui.components.LBTopAppBar
 import com.loryblu.core.ui.theme.LBContentHome
+import com.loryblu.data.logbook.local.getAllShiftItems
 import com.loryblu.data.logbook.remote.model.LogbookTask
 import com.loryblu.feature.home.R
+import com.loryblu.feature.logbook.ui.components.FrequencyBar
+import com.loryblu.feature.logbook.ui.components.ShiftBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
@@ -44,7 +52,15 @@ fun LogbookScreen(
     onNextScreenClicked: () -> Unit,
     userTasks: ApiResponseWithData<List<LogbookTask>>,
     selectADayOfWeek: (Int) -> Unit,
-    ) {
+) {
+
+    val selectedDay = remember {
+        mutableStateListOf<Int>(1)
+    }
+    val shiftSelected = remember {
+        mutableStateOf(0)
+    }
+
     Scaffold(
         topBar = {
             LBTopAppBar(
@@ -62,48 +78,33 @@ fun LogbookScreen(
                     .padding(innerPadding)
                     .verticalScroll(rememberScrollState())
             ) {
-                Spacer(modifier = Modifier.height(108.dp))
+
+                TasksSelector(
+                    selectedDay = selectedDay,
+                    shiftSelected = shiftSelected.value,
+                    onShiftChange = selectADayOfWeek
+                )
+
+                Spacer(modifier = Modifier.height(50.dp))
                 Column(
                     horizontalAlignment = Alignment.End,
                     modifier = Modifier
                         .fillMaxWidth()
                         .weight(0.85f)
                 ) {
-                    Image(
-                        painter = painterResource(com.loryblu.data.logbook.R.drawable.screen_home_logbook),
-                        contentDescription = null,
-                        modifier = Modifier
-                            .width(327.dp)
-                            .height(302.dp)
-                            .align(Alignment.CenterHorizontally),
-                        contentScale = ContentScale.Crop
-                    )
-                    Text(
-                        fontSize = 18.sp,
-                        text = stringResource(R.string.no_task_found),
-                        color = Color.Black,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier
-                            .padding(
-                                top = 28.dp,
-                                end = 9.dp
-                            )
-                            .align(Alignment.CenterHorizontally)
-                    )
+                    NoAssignmentsLayout()
                 }
-                Column(
-                    horizontalAlignment = Alignment.End,
+                Box(
+                    contentAlignment = Alignment.BottomEnd,
                     modifier = Modifier
-                        .weight(0.15f)
-                        .fillMaxSize()
-                        .padding(end = 20.dp),
+                        .fillMaxSize(),
                 ) {
                     ExtendedFloatingActionButton(
                         modifier = Modifier
-                            .padding(bottom = 0.dp, end = 20.dp),
+                            .padding(bottom = 16.dp, end = 16.dp),
                         containerColor = LBContentHome,
                         onClick = {
-                                  onNextScreenClicked()
+                            onNextScreenClicked()
                         },
                         shape = ShapeDefaults.ExtraLarge
                     ) {
@@ -122,6 +123,59 @@ fun LogbookScreen(
         }
     )
 }
+
+@Composable
+fun ColumnScope.NoAssignmentsLayout(modifier: Modifier = Modifier) {
+    Image(
+        painter = painterResource(com.loryblu.data.logbook.R.drawable.screen_home_logbook),
+        contentDescription = null,
+        modifier = Modifier
+            .width(327.dp)
+            .height(302.dp)
+            .align(Alignment.CenterHorizontally),
+        contentScale = ContentScale.Crop
+    )
+    Text(
+        fontSize = 18.sp,
+        text = stringResource(R.string.no_task_found),
+        color = Color.Black,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier
+            .padding(
+                top = 28.dp,
+                end = 9.dp
+            )
+            .align(Alignment.CenterHorizontally)
+    )
+}
+
+@Composable
+fun TasksSelector(
+    selectedDay: List<Int>,
+    shiftSelected: Int,
+    onShiftChange: (Int) -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxWidth()
+    ) {
+        FrequencyBar(
+            selectedDay = selectedDay,
+            onDayClicked = {
+                onShiftChange(it)
+            }
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        ShiftBar(
+            modifier = Modifier.padding(horizontal = 10.dp),
+            shiftSelected = shiftSelected,
+            onShiftChange = {},
+            options = getAllShiftItems()
+        )
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 fun HomeLogbookScreenPreview() {

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/home/LogbookScreen.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/home/LogbookScreen.kt
@@ -1,4 +1,4 @@
-package com.loryblu.feature.logbook.ui
+package com.loryblu.feature.logbook.ui.home
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.Image
@@ -30,8 +30,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.loryblu.core.network.model.ApiResponseWithData
 import com.loryblu.core.ui.components.LBTopAppBar
 import com.loryblu.core.ui.theme.LBContentHome
+import com.loryblu.data.logbook.remote.model.LogbookTask
 import com.loryblu.feature.home.R
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -40,6 +42,8 @@ import com.loryblu.feature.home.R
 fun LogbookScreen(
     onBackButtonClicked: () -> Unit,
     onNextScreenClicked: () -> Unit,
+    userTasks: ApiResponseWithData<List<LogbookTask>>,
+    selectADayOfWeek: (Int) -> Unit,
     ) {
     Scaffold(
         topBar = {
@@ -124,5 +128,7 @@ fun HomeLogbookScreenPreview() {
     LogbookScreen(
         onBackButtonClicked = {},
         onNextScreenClicked = {},
+        userTasks = ApiResponseWithData.Default(),
+        selectADayOfWeek = {},
     )
 }

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/CategoryScreen.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/CategoryScreen.kt
@@ -1,4 +1,4 @@
-package com.loryblu.feature.logbook.ui
+package com.loryblu.feature.logbook.ui.task
 
 import LBProgressBar
 import androidx.compose.foundation.layout.Arrangement

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/LogbookTaskViewModel.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/LogbookTaskViewModel.kt
@@ -30,6 +30,8 @@ class LogbookTaskViewModel(
         logbookTaskModel.frequency = frequency
     }
 
+    fun getLogbookTaskModel() : LogbookTaskModel = logbookTaskModel
+
     fun createLogbookTask() = viewModelScope.launch {
         val childId = session.getChildId()
         val logbookRequest = LogbookTaskRequest(

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/LogbookTaskViewModel.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/LogbookTaskViewModel.kt
@@ -1,4 +1,4 @@
-package com.loryblu.feature.logbook
+package com.loryblu.feature.logbook.ui.task
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -9,7 +9,7 @@ import com.loryblu.feature.logbook.model.Category
 import com.loryblu.feature.logbook.model.LogbookTaskModel
 import kotlinx.coroutines.launch
 
-class LogbookViewModel(
+class LogbookTaskViewModel(
     private val session: Session,
     private val logbookTaskModel: LogbookTaskModel,
     private val logbookApi: LogbookApi

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/ShiftScreen.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/ShiftScreen.kt
@@ -1,4 +1,4 @@
-package com.loryblu.feature.logbook.ui
+package com.loryblu.feature.logbook.ui.task
 
 import LBProgressBar
 import androidx.compose.foundation.layout.Arrangement

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/SummaryScreen.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/SummaryScreen.kt
@@ -1,0 +1,327 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.loryblu.feature.logbook.ui.task
+
+import LBProgressBar
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.loryblu.core.ui.components.LBButton
+import com.loryblu.core.ui.components.LBTaskCard
+import com.loryblu.core.ui.components.LBTopAppBar
+import com.loryblu.core.ui.theme.LBDarkBlue
+import com.loryblu.core.ui.theme.LBLightGray
+import com.loryblu.core.ui.theme.LBShadowGray
+import com.loryblu.core.ui.theme.LBSkyBlue
+import com.loryblu.data.logbook.local.RoutineTaskItem
+import com.loryblu.data.logbook.local.getAllRoutineItems
+import com.loryblu.data.logbook.local.getAllShiftItems
+import com.loryblu.feature.home.R
+import com.loryblu.feature.logbook.model.Category
+import com.loryblu.feature.logbook.model.LogbookTaskModel
+import com.loryblu.feature.logbook.ui.components.FrequencyBar
+import com.loryblu.feature.logbook.ui.components.ShiftBar
+
+@Composable
+fun SummaryScreen(
+    onBackButtonClicked: () -> Unit,
+    onCloseButtonClicked: () -> Unit,
+    logbookTaskModel: LogbookTaskModel,
+    onNextScreenClicked: () -> Unit,
+) {
+
+    val shiftSelected = getShiftSelected(logbookTaskModel.shift)
+    val selectedDay = getDaySelected(logbookTaskModel.frequency)
+
+    Scaffold(
+        topBar = {
+            LBTopAppBar(
+                title = stringResource(R.string.logbook_title),
+                onBackClicked = onBackButtonClicked,
+                onCloseClicked = onCloseButtonClicked,
+                showCloseButton = true
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(24.dp), horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                LBProgressBar(modifier = Modifier.fillMaxWidth(), currentStep = 4)
+                Spacer(modifier = Modifier.size(8.dp))
+                getTask(taskId = logbookTaskModel.task)?.let { taskItem ->
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn()
+                    ) {
+                        val painter = painterResource(taskItem.drawable)
+                        Spacer(Modifier.weight(0.25f))
+                        LBTaskCard(
+                            card = taskItem,
+                            modifier = Modifier
+                                .size(150.dp)
+                                .aspectRatio(painter.intrinsicSize.width / painter.intrinsicSize.height)
+                                .fillMaxWidth(),
+                            selected = true,
+                            onclick = { })
+                        Spacer(Modifier.weight(0.25f))
+                    }
+                    Spacer(modifier = Modifier.size(8.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(start = 24.dp),
+                            text = stringResource(R.string.categoryTitle),
+                            style = TextStyle(
+                                fontSize = 20.sp,
+                                lineHeight = 24.sp,
+                                fontWeight = FontWeight(500),
+                                color = Color.Black,
+                                textAlign = TextAlign.Start,
+                            )
+                        )
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .clip(RoundedCornerShape(8.dp))
+                                .background(LBDarkBlue)
+                        ) {
+                            Text(
+                                modifier = Modifier
+                                    .padding(8.dp)
+                                    .align(Alignment.Center),
+                                text = stringResource(id = taskItem.text),
+                                style = TextStyle(
+                                    fontSize = 20.sp,
+                                    lineHeight = 24.sp,
+                                    fontWeight = FontWeight(500),
+                                    color = Color.White,
+                                    textAlign = TextAlign.Center,
+                                )
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.size(8.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(start = 24.dp), text = stringResource(R.string.taskTitle), style = TextStyle(
+                                fontSize = 20.sp,
+                                lineHeight = 16.sp,
+                                fontWeight = FontWeight(500),
+                                color = Color.Black,
+                                textAlign = TextAlign.Start,
+                            )
+                        )
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .clip(RoundedCornerShape(8.dp))
+                                .background(LBDarkBlue)
+                        )
+                        {
+                            Text(
+                                modifier = Modifier
+                                    .padding(8.dp)
+                                    .align(Alignment.Center),
+                                text = logbookTaskModel.category.action,
+                                style = TextStyle(
+                                    fontSize = 20.sp,
+                                    lineHeight = 16.sp,
+                                    fontWeight = FontWeight(500),
+                                    color = Color.White,
+                                    textAlign = TextAlign.Center,
+                                )
+                            )
+                        }
+                    }
+                }
+                HorizontalDivider(
+                    modifier = Modifier
+                        .padding(top = 24.dp, bottom = 24.dp)
+                        .drawWithContent {
+                            drawContent()
+                            drawLine(
+                                color = LBLightGray,
+                                start = Offset(0.dp.toPx(), size.height / 2),
+                                end = Offset(size.width, size.height / 2),
+                                strokeWidth = 2.dp.toPx(),
+                                cap = StrokeCap.Round
+                            )
+                        }
+                        .graphicsLayer(clip = true),
+                    thickness = 2.dp
+                )
+
+                Text(
+                    modifier = Modifier.align(Alignment.Start),
+                    text = stringResource(R.string.shiftTitle), style = TextStyle(
+                        fontSize = 20.sp,
+                        lineHeight = 24.sp,
+                        fontWeight = FontWeight(500),
+                        color = Color.Black,
+                        textAlign = TextAlign.Start,
+                    )
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                ShiftBar(
+                    modifier = Modifier.fillMaxWidth(),
+                    shiftSelected = shiftSelected,
+                    onShiftChange = { },
+                    options = getAllShiftItems()
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                Text(
+                    style = TextStyle(
+                        fontSize = 20.sp,
+                        lineHeight = 24.sp,
+                        fontWeight = FontWeight(500),
+                        color = Color.Black,
+                        textAlign = TextAlign.Start,
+                    ), modifier = Modifier
+                        .padding(bottom = 4.dp)
+                        .align(Alignment.Start),
+                    text = stringResource(R.string.frequencyTitle)
+                )
+                Text(
+                    modifier = Modifier.align(Alignment.Start),
+                    text = stringResource(id = R.string.select_a_frequency_description),
+                    style = TextStyle(
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight(500),
+                        color = Color.Black,
+                        textAlign = TextAlign.Start,
+                    )
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                FrequencyBar(selectedDay = selectedDay, onDayClicked = { })
+            }
+            Box(modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(24.dp)) {
+                LBButton(
+                    textRes = R.string.registerTask,
+                    onClick = {
+                    },
+                    buttonColors = ButtonDefaults.buttonColors(
+                        disabledContainerColor = LBLightGray,
+                        containerColor = LBSkyBlue
+                    ),
+                    textColor = Color.White,
+                    areAllFieldsValid = true
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun getTask(taskId: String): RoutineTaskItem? {
+    val tasks = getAllRoutineItems()
+    val task = tasks.find {
+        it.taskId == taskId
+    }
+    return task
+}
+
+@Composable
+private fun getShiftSelected(shift: String): Int {
+    return when (shift) {
+        "morning" -> {
+            0
+        }
+
+        "afternoon" -> {
+            1
+        }
+
+        else -> {
+            2
+        }
+    }
+}
+
+@Composable
+private fun getDaySelected(days: List<String>): List<Int> {
+    val selectedDays = remember { mutableStateListOf<Int>() }
+    val nameOfWeekDays = arrayOf("sun", "mon", "tue", "wed", "thu", "fri", "sat")
+    nameOfWeekDays.forEachIndexed { index, day ->
+        if (days.any { it.contains(day) }) {
+            selectedDays.add(index)
+        }
+    }
+    return selectedDays
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SummaryPreview() {
+    SummaryScreen(
+        onBackButtonClicked = { },
+        onCloseButtonClicked = { },
+        logbookTaskModel = LogbookTaskModel(
+            category = Category.ROUTINE,
+            task = "6dfc15bb-f422-4c75-b2cc-bf3e9806c76a",
+            shift = "morning",
+            frequency = listOf("sun", "mon")
+        ),
+        onNextScreenClicked = { },
+    )
+}

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/SummaryScreen.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/SummaryScreen.kt
@@ -3,9 +3,11 @@
 package com.loryblu.feature.logbook.ui.task
 
 import LBProgressBar
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,12 +21,15 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
@@ -40,12 +45,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -57,10 +64,12 @@ import androidx.compose.ui.unit.sp
 import com.loryblu.core.ui.components.LBButton
 import com.loryblu.core.ui.components.LBTaskCard
 import com.loryblu.core.ui.components.LBTopAppBar
+import com.loryblu.core.ui.theme.LBCardSoftBlue
 import com.loryblu.core.ui.theme.LBDarkBlue
 import com.loryblu.core.ui.theme.LBLightGray
 import com.loryblu.core.ui.theme.LBShadowGray
 import com.loryblu.core.ui.theme.LBSkyBlue
+import com.loryblu.core.ui.theme.LBSoftBlue
 import com.loryblu.data.logbook.local.RoutineTaskItem
 import com.loryblu.data.logbook.local.getAllRoutineItems
 import com.loryblu.data.logbook.local.getAllShiftItems
@@ -106,20 +115,27 @@ fun SummaryScreen(
                 getTask(taskId = logbookTaskModel.task)?.let { taskItem ->
                     Row(
                         Modifier
-                            .fillMaxWidth()
-                            .heightIn()
+                            .fillMaxWidth().padding(16.dp)
                     ) {
-                        val painter = painterResource(taskItem.drawable)
-                        Spacer(Modifier.weight(0.25f))
-                        LBTaskCard(
-                            card = taskItem,
-                            modifier = Modifier
-                                .size(150.dp)
-                                .aspectRatio(painter.intrinsicSize.width / painter.intrinsicSize.height)
-                                .fillMaxWidth(),
-                            selected = true,
-                            onclick = { })
-                        Spacer(Modifier.weight(0.25f))
+                        Spacer(Modifier.weight(1f))
+                        OutlinedCard(
+                            colors = CardDefaults.cardColors(
+                                containerColor = LBCardSoftBlue,
+                            ),
+                            border = BorderStroke(4.dp, LBDarkBlue),
+                            shape = RoundedCornerShape(5),
+                        ) {
+                            Image(
+                                alignment = Alignment.TopCenter,
+                                modifier = Modifier
+                                    .padding(4.dp)
+                                    .alpha(1f),
+                                painter = painterResource(id = taskItem.drawable),
+                                contentDescription = stringResource(id = taskItem.text),
+                                contentScale = ContentScale.Fit,
+                            )
+                        }
+                        Spacer(Modifier.weight(1f))
                     }
                     Spacer(modifier = Modifier.size(8.dp))
                     Row(verticalAlignment = Alignment.CenterVertically) {
@@ -146,7 +162,7 @@ fun SummaryScreen(
                                 modifier = Modifier
                                     .padding(8.dp)
                                     .align(Alignment.Center),
-                                text = stringResource(id = taskItem.text),
+                                text = logbookTaskModel.category.action,
                                 style = TextStyle(
                                     fontSize = 20.sp,
                                     lineHeight = 24.sp,
@@ -181,7 +197,7 @@ fun SummaryScreen(
                                 modifier = Modifier
                                     .padding(8.dp)
                                     .align(Alignment.Center),
-                                text = logbookTaskModel.category.action,
+                                text = stringResource(id = taskItem.text),
                                 style = TextStyle(
                                     fontSize = 20.sp,
                                     lineHeight = 16.sp,
@@ -252,6 +268,7 @@ fun SummaryScreen(
                 )
                 Spacer(modifier = Modifier.size(8.dp))
                 FrequencyBar(selectedDay = selectedDay, onDayClicked = { })
+                Spacer(Modifier.weight(1f))
             }
             Box(modifier = Modifier
                 .align(Alignment.BottomCenter)

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/SummaryScreen.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/SummaryScreen.kt
@@ -115,7 +115,7 @@ fun SummaryScreen(
                 getTask(taskId = logbookTaskModel.task)?.let { taskItem ->
                     Row(
                         Modifier
-                            .fillMaxWidth().padding(16.dp)
+                            .fillMaxWidth().heightIn().padding(16.dp)
                     ) {
                         Spacer(Modifier.weight(1f))
                         OutlinedCard(

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/TaskScreen.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/ui/task/TaskScreen.kt
@@ -1,4 +1,4 @@
-package com.loryblu.feature.logbook.ui
+package com.loryblu.feature.logbook.ui.task
 
 import LBProgressBar
 import android.annotation.SuppressLint

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/useCases/GetUserTaskByDayOfWeek.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/useCases/GetUserTaskByDayOfWeek.kt
@@ -1,0 +1,9 @@
+package com.loryblu.feature.logbook.useCases
+
+import com.loryblu.core.network.model.ApiResponseWithData
+import com.loryblu.data.logbook.remote.model.LogbookTask
+import kotlinx.coroutines.flow.Flow
+
+interface GetUserTaskByDayOfWeek {
+    suspend fun invoke(dayOfWeek: String): Flow<ApiResponseWithData<List<LogbookTask>>>
+}

--- a/feature/logbook/src/main/java/com/loryblu/feature/logbook/useCases/GetUserTaskByDayOfWeekImpl.kt
+++ b/feature/logbook/src/main/java/com/loryblu/feature/logbook/useCases/GetUserTaskByDayOfWeekImpl.kt
@@ -1,0 +1,41 @@
+package com.loryblu.feature.logbook.useCases
+
+import com.loryblu.core.network.model.ApiResponseWithData
+import com.loryblu.data.logbook.remote.api.LogbookApi
+import com.loryblu.data.logbook.remote.model.LogbookTask
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+internal class GetUserTaskByDayOfWeekImpl(
+    private val logbookRepository: LogbookApi
+): GetUserTaskByDayOfWeek {
+    private val userTasks: MutableList<LogbookTask> = mutableListOf()
+
+    override suspend fun invoke(dayOfWeek: String): Flow<ApiResponseWithData<List<LogbookTask>>> = flow {
+        if(userTasks.isNotEmpty()) {
+            emit(
+                ApiResponseWithData.Success(
+                    getTasksByDayOfWeek(userTasks, dayOfWeek)
+                )
+            )
+        } else {
+            logbookRepository.getUserTasks().collect {
+                emit(it)
+                if(it == ApiResponseWithData.Success::class) {
+                    userTasks.addAll(it.data!!)
+                }
+            }
+        }
+    }
+
+    private fun getTasksByDayOfWeek(list: List<LogbookTask>, dayOfWeek: String): List<LogbookTask> {
+        val result = mutableListOf<LogbookTask>()
+        list.forEach {
+            if(it.frequency.contains(dayOfWeek)) {
+                result.add(it)
+            }
+        }
+        return result
+    }
+
+}

--- a/feature/logbook/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/logbook/src/main/res/values-pt-rBR/strings.xml
@@ -14,4 +14,9 @@
     <string name="new_task">NOVA TAREFA</string>
     <string name="next">PRÓXIMO</string>
     <string name="confirm">CONFIRMAR</string>
+    <string name="registerTask">CADASTRAR</string>
+    <string name="categoryTitle">Categoria:</string>
+    <string name="taskTitle">Tarefa:</string>
+    <string name="shiftTitle">Turno:</string>
+    <string name="frequencyTitle">Frequência:</string>
 </resources>

--- a/feature/logbook/src/main/res/values/strings.xml
+++ b/feature/logbook/src/main/res/values/strings.xml
@@ -13,4 +13,9 @@
     <string name="new_task">ADD TASK</string>
     <string name="next">NEXT</string>
     <string name="confirm">CONFIRM</string>
+    <string name="registerTask">REGISTER</string>
+    <string name="categoryTitle">Category:</string>
+    <string name="taskTitle">Task:</string>
+    <string name="shiftTitle">Shift:</string>
+    <string name="frequencyTitle">Frequency:</string>
 </resources>


### PR DESCRIPTION
## Task

This pull request refers to task LOR-218

- [ ] Does not apply to this pull request

## Description

Update the back stack navigation logic. The user should be able to return to the home screen by clicking the close button or navigate back to the previous screen in the logbook task flow.

## Types of changes #

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## What changed: #

- [X] UI
- [ ] Business rule
- [ ] Documentation
- [ ] Gradle or Build
- [x] Navigation
- [ ] Tests
- [ ] Resource files
- [ ] Project architecture
- [ ] Code style

## Checklist #

- [X] Have tested the changes.
- [X] Met all the acceptance requirements of this task.
- [X] Verified if branch is up-to-date with `development` (if not - rebase it or merge it).
- [X] Resolve git conflicts

## If any of the acceptance criteria are not met, please explain why below #
What is the criteria? Why it is different?
