### PR TITLE
fix(logbook): Tasks not showing

### DIFF
--- a/data/logbook/src/main/java/com/loryblu/data/logbook/remote/model/LogbookTaskRemote.kt
+++ b/data/logbook/src/main/java/com/loryblu/data/logbook/remote/model/LogbookTaskRemote.kt
@@ -7,8 +7,8 @@ data class LogbookTaskRemote(
 
 data class Data(
     val count: Int,
-    val routine: List<LogbookRemoteItem>,
-    val study: List<LogbookRemoteItem>
+    val routine: List<LogbookRemoteItem>?,
+    val study: List<LogbookRemoteItem>?,
 )
 
 data class LogbookRemoteItem(

--- a/data/logbook/src/main/java/com/loryblu/data/logbook/util/RemoteExtensions.kt
+++ b/data/logbook/src/main/java/com/loryblu/data/logbook/util/RemoteExtensions.kt
@@ -28,7 +28,7 @@ fun LogbookTaskRemote.toLogbookTask(): List<LogbookTask> {
     val idToCard = TaskItem.getAllTaskItems().associateBy { it.taskId }
     val logbookItems = mutableListOf<LogbookTask>()
 
-    this.data.routine.map { remote ->
+    this.data.routine?.map { remote ->
         logbookItems.add(
             LogbookTask(
             itemOfCategory = idToCard[remote.categoryId]!!,
@@ -40,7 +40,7 @@ fun LogbookTaskRemote.toLogbookTask(): List<LogbookTask> {
             )
         )
     }
-    this.data.study.map { remote ->
+    this.data.study?.map { remote ->
         logbookItems.add(
             LogbookTask(
                 itemOfCategory = idToCard[remote.categoryId]!!,


### PR DESCRIPTION
fix(logbook): Tasks not showing when has tasks of just one type "routine" or "study"

## Task

This pull request refers to task LOR-XX

- [x] Does not apply to this pull request

## Description

Quando tinha tasks adicionadas de apenas um tipo, por exemplo todas as tasks da minha conta eram do LoryEstudioso eles não estavam sendo exibidas.

## Types of changes #

- [ ] New feature (non-breaking change which adds functionality).
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## What changed: #

- [ ] UI
- [x] Business rule
- [ ] Documentation
- [ ] Gradle or Build
- [ ] Navigation
- [ ] Tests
- [ ] Resource files
- [ ] Project architecture
- [ ] Code style

## Checklist #

- [x] Have tested the changes.
- [x] Met all the acceptance requirements of this task.
- [x] Verified if branch is up-to-date with `development` (if not - rebase it or merge it).
- [x] Resolve git conflicts

## If any of the acceptance criteria are not met, please explain why below #
What is the criteria? Why it is different?
